### PR TITLE
Publish UEFI patches for edk2-stable202211

### DIFF
--- a/edk2-stable202211/0001-edk2-stable202211-nitro-add-build-script.patch
+++ b/edk2-stable202211/0001-edk2-stable202211-nitro-add-build-script.patch
@@ -1,0 +1,117 @@
+From bc78135d35d2a275e6b8d8c0c1e3d6ca35fc9be9 Mon Sep 17 00:00:00 2001
+From: Razvan Ghitulete <rga@amazon.com>
+Date: Tue, 12 Jun 2018 08:26:55 -0500
+Subject: [PATCH] nitro: add build script
+
+In order to keep things as simple as possible, we create build.sh to
+interact with the build system.
+
+Signed-off-by: Razvan Ghitulete <rga@amazon.com>
+Signed-off-by: Peter Lawthers <lawthers@amazon.com>
+Signed-off-by: Julian Stecklina <jsteckli@amazon.de>
+Signed-off-by: David Woodhouse <dwmw@amazon.co.uk>
+Signed-off-by: Hendrik Borghorst <hborghor@amazon.de>
+Signed-off-by: Simon Veith <sveith@amazon.de>
+Signed-off-by: Sabin Rapan <sabrapan@amazon.com>
+Signed-off-by: Costin Lupu <lvpv@amazon.com>
+Reviewed-by: Amadeusz Juskowiak <ajusk@amazon.de>
+Reviewed-by: Marius Hillenbrand <mhillenb@amazon.de>
+Reviewed-by: Norbert Manthey <nmanthey@amazon.de>
+Reviewed-by: Filippo Sironi <sironi@amazon.de>
+Reviewed-by: Alexander Graf (AWS) <graf@amazon.de>
+Reviewed-by: Alexandru Ciobotaru <alcioa@amazon.com>
+Reviewed-by: Petre Eftime <epetre@amazon.com>
+Reviewed-by: Alexandru-Catalin Vasile <lexnv@amazon.com>
+CC: KarimAllah Raslan <karahmed@amazon.de>
+
+diff --git a/build.sh b/build.sh
+new file mode 100755
+index 0000000000..b7fc92bae7
+--- /dev/null
++++ b/build.sh
+@@ -0,0 +1,85 @@
++#!/bin/bash
++# Copyright 2018-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
++set -e -o pipefail
++
++ARCH_TARGET="$1"
++
++# Check parameters
++SUPPORTED_ARCH="arm64 x86"
++if [[ ! " $SUPPORTED_ARCH " =~ .*\ $ARCH_TARGET\ .* ]]; then
++	echo "Usage: $0 <arch>"
++	echo "Supported architectures: ${SUPPORTED_ARCH[@]}"
++	exit 2
++fi
++
++SOURCE="${BASH_SOURCE[0]}"
++# resolve ${SOURCE} until the file is no longer a symlink
++SOURCE="$(readlink -e ${SOURCE})"
++DIR="$( cd -P "$( dirname ${SOURCE} )" && pwd )"
++PACKAGES_PATH=${PACKAGES_PATH:-$DIR}
++LOGFILE="uefi_build.log"
++
++cd ${DIR}
++
++TPUT="$([ -z "${TERM}" -o "${TERM}" = dumb ] && echo true || echo tput)"
++
++${TPUT} setaf 2
++echo "     BUILD  uefi"
++echo "      LOGS  ${DIR}/${LOGFILE}"
++${TPUT} sgr0
++
++unset MAKEFLAGS
++unset MAKELEVEL
++
++# You can never be too safe. Just set these vars to '' to make sure no unwanted side effects occur
++export CONF_PATH=''
++export EDK_TOOLS_PATH=''
++export WORKSPACE=''
++
++# Set SOURCE_DATE_EPOCH for reproducible builds (can be overriden)
++export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-$(date --date='Nov 1 2018 09:00:00' +"%s")}
++
++if [ -n "$UEFI_DEBUG" ]; then
++	BUILD_TYPE="DEBUG"
++else
++	BUILD_TYPE="RELEASE"
++fi
++
++TOOLCHAIN="GCC5"
++
++#
++# build uefi in it's special build environment. This should be done last
++# since it modifies the build environment
++#
++build_uefi()
++{
++	# We only care about the latest build log so we just
++	# wipe everything that might be in the build log
++	echo "      MAKE  BaseTools"
++	make -C BaseTools &> "${LOGFILE}"
++	source edksetup.sh >> "${LOGFILE}"
++
++	if [ "$ARCH_TARGET" = "x86" ]; then
++	    # Build OVMF for booting x86_64 Nitro Guests
++	    echo "     BUILD  OvmfPkg"
++
++	    defines="${defines} -DTPM_ENABLE=TRUE"
++	    [ -n "$UEFI_DEBUG" ] && defines="${defines} -DDEBUG_ON_SERIAL_PORT"
++
++	    build -a X64 -t $TOOLCHAIN -b $BUILD_TYPE --hash -p OvmfPkg/OvmfPkgX64.dsc ${defines} >> "${LOGFILE}"
++	    cp Build/OvmfX64/${BUILD_TYPE}_${TOOLCHAIN}/FV/OVMF.fd ovmf_img.fd
++
++	elif [ "$ARCH_TARGET" = "arm64" ]; then
++	    # Build ArmvirtQemuKernel, passed to Nitro Guests
++	    echo "     BUILD  ArmVirtQemuKernel"
++	    build -a AARCH64 -t $TOOLCHAIN -b $BUILD_TYPE --hash -p ArmVirtPkg/ArmVirtQemuKernel.dsc >> "${LOGFILE}"
++	    cp Build/ArmVirtQemuKernel-AARCH64/${BUILD_TYPE}_${TOOLCHAIN}/FV/QEMU_EFI.fd uefi_img.fd
++
++	else
++	    echo "ERROR: Unknown UEFI build target ${ARCH_TARGET}"
++	    exit 1
++	fi
++}
++
++build_uefi
++

--- a/edk2-stable202211/0002-edk2-stable202211-uefi-Set-number-of-queues-upon-controller-initialization.patch
+++ b/edk2-stable202211/0002-edk2-stable202211-uefi-Set-number-of-queues-upon-controller-initialization.patch
@@ -1,0 +1,159 @@
+From 0a62f7922358e178d84afdeaebf2286445d1dd33 Mon Sep 17 00:00:00 2001
+From: Simon Veith <sveith@amazon.de>
+Date: Tue, 28 Aug 2018 19:45:57 +0200
+Subject: [PATCH] uefi: Set number of queues upon controller initialization
+
+The NVMe implementation in Nitro expects a driver to first request a
+certain number of completion and submission queues using the "Number of
+Queues" feature before using any of them. Otherwise, it defaults to
+providing zero queues each.
+
+UEFI has not been aware of this requirement and defaulted to simply using
+the two queues it needs of each type. This change implements the logic
+required for issuing the NVMe "Set Features" command in order to properly
+set up the queues, thus allowing UEFI to boot on droplets.
+
+This restriction has not been an issue in the QEMU environment because its
+NVMe implementation provides 64 queues each, no matter what the guest has
+requested.
+
+Signed-off-by: Simon Veith <sveith@amazon.de>
+Signed-off-by: Costin Lupu <lvpv@amazon.com>
+Reviewed-by: KarimAllah Ahmed <karahmed@amazon.de>
+Reviewed-by: Ali Saidi <alisaidi@amazon.com>
+Reviewed-by: Peter Lawthers <lawthers@amazon.de>
+
+diff --git a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+index b90c48731c..1423b03b8c 100644
+--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
++++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+@@ -558,6 +558,59 @@ NvmeIdentifyNamespace (
+   return Status;
+ }
+ 
++/**
++  Request a number of submission and request queues from a NVMe controller.
++
++  @param  Private          The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
++  @param  NumCQsRequested  Number of completion queues to request
++  @param  NumSQsRequested  Number of submission queues to request
++
++  @return EFI_SUCCESS      Successfully allocated at least the requested number of queues.
++  @return EFI_DEVICE_ERROR Failed to allocate some or all of the requested queues.
++
++**/
++EFI_STATUS
++NvmeSetNumberOfQueues (
++  IN NVME_CONTROLLER_PRIVATE_DATA      *Private,
++  IN UINT16                             NumCQsRequested,
++  IN UINT16                             NumSQsRequested
++  )
++{
++  EFI_NVM_EXPRESS_PASS_THRU_COMMAND_PACKET CommandPacket;
++  EFI_NVM_EXPRESS_COMMAND                  Command;
++  EFI_NVM_EXPRESS_COMPLETION               Completion;
++  EFI_STATUS                               Status;
++
++  DEBUG ((EFI_D_INFO, "Requesting %d completion queues and %d submission "
++                      "queues\n", NumCQsRequested, NumSQsRequested));
++
++  ZeroMem (&CommandPacket, sizeof(EFI_NVM_EXPRESS_PASS_THRU_COMMAND_PACKET));
++  ZeroMem (&Command, sizeof(EFI_NVM_EXPRESS_COMMAND));
++  ZeroMem (&Completion, sizeof(EFI_NVM_EXPRESS_COMPLETION));
++
++  CommandPacket.NvmeCmd        = &Command;
++  CommandPacket.NvmeCompletion = &Completion;
++
++  CommandPacket.CommandTimeout = NVME_GENERIC_TIMEOUT;
++  CommandPacket.QueueType      = NVME_ADMIN_QUEUE;
++
++  Command.Cdw0.Opcode          = NVME_ADMIN_SET_FEATURES_CMD;
++  Command.Cdw10                = NVME_FID_NUMBER_OF_QUEUES;
++  Command.Cdw11                = ((UINT32)NumCQsRequested << 16)
++                                 | NumSQsRequested;
++
++  Command.Flags                = CDW10_VALID | CDW11_VALID;
++
++  Status = Private->Passthru.PassThru (
++                               &Private->Passthru,
++                               0,
++                               &CommandPacket,
++                               NULL
++                               );
++
++  return Status;
++}
++
+ /**
+   Create io completion queue.
+ 
+@@ -912,6 +965,12 @@ NvmeControllerInit (
+   DEBUG ((DEBUG_INFO, "    CQES      : 0x%x\n", Private->ControllerData->Cqes));
+   DEBUG ((DEBUG_INFO, "    NN        : 0x%x\n", Private->ControllerData->Nn));
+ 
++  Status = NvmeSetNumberOfQueues (Private, 2, 2);
++  if (EFI_ERROR(Status)) {
++   DEBUG((DEBUG_ERROR, "NvmeControllerInit: failed to set number of queues\n"));
++   return Status;
++  }
++
+   //
+   // Create two I/O completion queues.
+   // One for blocking I/O, one for non-blocking I/O.
+diff --git a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
+index f37baa626a..de79ea6be7 100644
+--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
++++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
+@@ -597,21 +597,10 @@ NvmExpressPassThru (
+   }
+ 
+   Sq->Prp[0] = (UINT64)(UINTN)Packet->TransferBuffer;
+-  if ((Packet->QueueType == NVME_ADMIN_QUEUE) &&
+-      ((Sq->Opc == NVME_ADMIN_CRIOCQ_CMD) || (Sq->Opc == NVME_ADMIN_CRIOSQ_CMD)))
+-  {
+-    //
+-    // Currently, we only use the IO Completion/Submission queues created internally
+-    // by this driver during controller initialization. Any other IO queues created
+-    // will not be consumed here. The value is little to accept external IO queue
+-    // creation requests, so here we will return EFI_UNSUPPORTED for external IO
+-    // queue creation request.
+-    //
+-    if (!Private->CreateIoQueue) {
+-      DEBUG ((DEBUG_ERROR, "NvmExpressPassThru: Does not support external IO queues creation request.\n"));
+-      return EFI_UNSUPPORTED;
+-    }
+-  } else if ((Sq->Opc & (BIT0 | BIT1)) != 0) {
++  if (((Sq->Opc & (BIT0 | BIT1)) != 0) &&
++      !((Packet->QueueType == NVME_ADMIN_QUEUE) && ((Sq->Opc == NVME_ADMIN_CRIOCQ_CMD)
++                                                    || (Sq->Opc == NVME_ADMIN_CRIOSQ_CMD)
++                                                    || (Sq->Opc == NVME_ADMIN_SET_FEATURES_CMD)))) {
+     //
+     // If the NVMe cmd has data in or out, then mapping the user buffer to the PCI controller specific addresses.
+     //
+diff --git a/MdePkg/Include/IndustryStandard/Nvme.h b/MdePkg/Include/IndustryStandard/Nvme.h
+index 4a1d92c45d..2e6d96ce05 100644
+--- a/MdePkg/Include/IndustryStandard/Nvme.h
++++ b/MdePkg/Include/IndustryStandard/Nvme.h
+@@ -1005,6 +1005,22 @@ typedef struct {
+   UINT8     Reserved2[296];
+ } NVME_SMART_HEALTH_INFO_LOG;
+ 
++//
++// Set Features - Feature Identifiers
++// (ref. spec. v1.1 Figure 89)
++//
++#define NVME_FID_ARBITRATION             0x01
++#define NVME_FID_POWER_MANAGEMENT        0x02
++#define NVME_FID_LBA_RANGE_TYPE          0x03
++#define NVME_FID_TEMPERATURE_THRESHOLD   0x04
++#define NVME_FID_ERROR_RECOVERY          0x05
++#define NVME_FID_VOLATILE_WRITE_CACHE    0x06
++#define NVME_FID_NUMBER_OF_QUEUES        0x07
++#define NVME_FID_INTERRUPT_COALESCING    0x08
++#define NVME_FID_INTERRUPT_VECTOR_CONFIG 0x09
++#define NVME_FID_WRITE_ATOMICITY         0x0A
++#define NVME_FID_ASYNC_EVENT_CONFIG      0x0B
++
+ #pragma pack()
+ 
+ #endif

--- a/edk2-stable202211/0003-edk2-stable202211-uefi-Apply-e820-reservations-from-fw-cfg.patch
+++ b/edk2-stable202211/0003-edk2-stable202211-uefi-Apply-e820-reservations-from-fw-cfg.patch
@@ -1,0 +1,34 @@
+From 5654c5c841a6d6b39ccbc7dce06051d446f6e35f Mon Sep 17 00:00:00 2001
+From: Alexander Graf <graf@amazon.com>
+Date: Thu, 21 May 2020 02:08:09 +0200
+Subject: [PATCH] uefi: Apply e820 reservations from fw-cfg
+
+This commit extends the parsing of the e820 fw-cfg file to also add the
+reserved memory regions so that guests properly see reserved memory
+regions.
+
+Signed-off-by: Alexander Graf <graf@amazon.de>
+Signed-off-by: Hendrik Borghorst <hborghor@amazon.de>
+Reviewed-by: David Woodhouse <dwmw@amazon.co.uk>
+Reviewed-by: Evgeny Iakovlev <eyakovl@amazon.de>
+Reviewed-by: Alexander Graf (AWS) <graf@amazon.de>
+
+diff --git a/OvmfPkg/Library/PlatformInitLib/MemDetect.c b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+index b8feae4309..b11aa76afc 100644
+--- a/OvmfPkg/Library/PlatformInitLib/MemDetect.c
++++ b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+@@ -181,6 +181,14 @@ PlatformScanOrAdd64BitE820Ram (
+       E820Entry.Length,
+       E820Entry.Type
+       ));
++    // Add e820 reserved regions
++    if (E820Entry.Type == EfiAcpiAddressRangeReserved) {
++      BuildMemoryAllocationHob (
++        E820Entry.BaseAddr,
++        E820Entry.Length,
++        EfiReservedMemoryType
++        );
++    }
+     if (E820Entry.Type == EfiAcpiAddressRangeMemory) {
+       if (AddHighHob && (E820Entry.BaseAddr >= BASE_4GB)) {
+         UINT64  Base;

--- a/edk2-stable202211/0004-edk2-stable202211-uefi-Add-Amazon-EC2-VGA-device-to-Qemu-video-driver.patch
+++ b/edk2-stable202211/0004-edk2-stable202211-uefi-Add-Amazon-EC2-VGA-device-to-Qemu-video-driver.patch
@@ -1,0 +1,40 @@
+From 36f752137b1d95bdf73a98e2cb50ddbfdba48e41 Mon Sep 17 00:00:00 2001
+From: Alexander Graf <graf@amazon.com>
+Date: Sun, 24 May 2020 20:50:14 +0200
+Subject: [PATCH] uefi: Add Amazon EC2 VGA device to Qemu video driver
+
+Amazon's EC2 VGA device is using a different PCI ID than the Qemu one.
+Add the device IDs and disable QXL support for the VGA device.
+
+Signed-off-by: Hendrik Borghorst <hborghor@amazon.de>
+Signed-off-by: Costin Lupu <lvpv@amazon.com>
+Reviewed-by: Evgeny Iakovlev <eyakovl@amazon.de>
+Reviewed-by: Alexander Graf (AWS) <graf@amazon.de>
+
+diff --git a/OvmfPkg/QemuVideoDxe/Driver.c b/OvmfPkg/QemuVideoDxe/Driver.c
+index c28171d137..912342be7d 100644
+--- a/OvmfPkg/QemuVideoDxe/Driver.c
++++ b/OvmfPkg/QemuVideoDxe/Driver.c
+@@ -69,6 +69,12 @@ QEMU_VIDEO_CARD  gQemuVideoCardList[] = {
+     0x0405,
+     QEMU_VIDEO_VMWARE_SVGA,
+     L"QEMU VMWare SVGA"
++  },{
++    PCI_CLASS_DISPLAY_VGA,
++    0x1d0f,
++    0x1111,
++    QEMU_VIDEO_BOCHS,
++    L"Amazon EC2 VGA"
+   },{
+     0     /* end of list */
+   }
+@@ -267,7 +273,8 @@ QemuVideoControllerDriverStart (
+   // IsQxl is based on the detected Card->Variant, which at a later point might
+   // not match Private->Variant.
+   //
+-  IsQxl = (BOOLEAN)(Card->Variant == QEMU_VIDEO_BOCHS);
++  // uEMU is emulating a Bochs VGA device. It is not emulating a QXL-compliant one, however. Disable it.
++  IsQxl = (BOOLEAN)(Card->Variant == QEMU_VIDEO_BOCHS && !StrnCmp(Card->Name, L"QEMU", 4));
+ 
+   //
+   // Save original PCI attributes

--- a/edk2-stable202211/0005-edk2-stable202211-uefi-bgrt-Change-boot-graphic-ACPI-OemID.patch
+++ b/edk2-stable202211/0005-edk2-stable202211-uefi-bgrt-Change-boot-graphic-ACPI-OemID.patch
@@ -1,0 +1,102 @@
+From 2aaa3fea5161b1b16bf53cf6c0ef0cb478b720a3 Mon Sep 17 00:00:00 2001
+From: Hendrik Borghorst <hborghor@amazon.de>
+Date: Thu, 15 Oct 2020 13:50:24 +0200
+Subject: [PATCH] uefi/bgrt: Change boot graphic, ACPI OemID
+
+On top of the logo change, also change the OemId and OemTableId.
+
+Signed-off-by: Hendrik Borghorst <hborghor@amazon.de>
+Reviewed-by: Alexander Graf (AWS) <graf@amazon.de>
+Reviewed-by: Jinank Jain <jinankj@amazon.de>
+
+diff --git a/MdeModulePkg/Logo/Logo.bmp b/MdeModulePkg/Logo/Logo.bmp
+index 3e85229e17595ba1f9c59e13692a4f8362ebc850..2be78fe556f43d3831b6d738ba3fb5c3c64df9e4 100644
+GIT binary patch
+literal 2898
+zcmZ?r4dP}1gDxOh1H^Jr%*Y@C7C*toz%Z8ug24h{;y(ie1c7-@?m@)}IpSDM#3>t9
+eH5vk=Aut*OqaiRF0;3@?8UmvsFd71bIs^cm`3R{1
+
+literal 12446
+zcmeHMTZkiB8UDNL(sk>qB-K?(I_Y$!(&<j8lk{|ICYjmv&Z?;R;QAo!gNTUWq9BWc
+zFusVQ4+<(i$Udzg?1O^rn;?Rqpn@O>3cf7*ATFZdips9zI<qqqzyF-7q>`T9o#~w!
+zZ0NsJw{!i!^Iy;DcRl%?3nXZy5_RzQGhC11S|LM}f3hbY^0p!>XgZw|JvF6wmsaTa
+zzxg$N|65<9=fC;|I$k4s;a5}o?Js^x&%Eaf{qjdYpqKyhXL@R{LLd0XlwSJ7i}dtl
+zK>pKH`rHTKOV?k0g?{qFcd2)6N*_6D(X-c{q0c_~4*JT|AExKNc#WR@@sz&)sgKb+
+z*NJ}j(v*Jw;*_p^Z%RLW{@Zl>)-C$y%YUPfKZkMuKBdop=t+9{l_}l4af4pF{%?By
+z=1uz2N1vkWH>ULJzy3jg{nH=m>X)Z<=gu9P;(FyjQ+j`Woxb^*PtbpFqTj74-M)RB
+zZoKvy-MY=~@Qv%!@4HI3UVj~Zxa>CFVeIF0z5?efaJ~ZPEASvzATiB}X_m!})Fhk{
+z8BrAZxR^$LWlp1Bzi;<#JGSk9zq#M(bjJJ}k2|9W!O{JXG12Qf|8NZ{^i0rXG65v=
+ztD1%%u4=WZ7$A!;%V@@~Aj`nxc&}HQ(L=(Z^xqtpSznceCsobzj06Ti0IAic%NSAu
+z2HSOQyQ{^0_qaJ?F?33$&bXIhIDGRt@3*!V-K9rvj<UYG3ibsO3h#<R)wE>{>cp(}
+zYe74*qpliP`@TQkQ?&7j`kGx!LR(WKrC&*GBO=wcEL*!k9W5sE4c{WIr}mAg6uPQG
+zS|zkpo1%8qL~Xkp#<;80sr1QeS39cWcEe6$Rupv5#;R*{s~z9yYn{ZO<1&FEqa`^&
+z08$Pb<iL8A$)V>DBg;{fKntS4_bkt?hR0X^2}V`ST3gj!r$4dUVI_&WG%>VLnOvnf
+zfJP*0qLO1z47FzHs?$}5{!ld)#j!kvs8(}pMZBAaqN^pxFZ$i6thK|cr<z*D_Bx&w
+z0Bt2wJjKC^WHixN>zO(&VzAg4B&GH+!_cnAv1(Sdj#&(96JXH7{Sn5GN{VTC?V%e`
+zF*5DGr`D*bsG4FPQqMDN3e`}hATAnFq6J>yDaE!Em0i^V?~IU26Kz;28ll-XhLtuj
+zcs-*GT{0_4?2U_R&}~Oaq)ZGm1Au2v4#T@(NF}kTOTDsc_kFK2F(3&eh#ad@Js$ai
+z+U{cX#2+eH>d3Ryc4YR=C~R90Q7<qjR;VTwduW)E)(xzBQc)AjR81dk0}B{5qN3&)
+zSa!pU0&AjHBG1seN!#_Rrs61`ANXyp7Fv+~{v3n}Da`C)(WZqAB#0#p)v_JeimDfc
+zZs=8dm5FEUjr=n8p$B%^4E=iOfPc?Wf^stPY612RJrBARSy50cmdkC^597qJ)T&wR
+zhfY*66Yx}1$#v||OOzUEmgcqNu5Wmzi;+~N>~+iSj_MVA(Zo|VUG6>v5Z0wPum{#9
+zRoKLmU+O7dvFliUSLwU^acNwNd*c%1kQ8f**KC$3o>14b_s2xX9oic=dGFH;Dxn68
+z-WyYA4>#dg4ykmEt<mwQ1e1nq4+DszboKC%E*w5y+NZWp9Ui6hIE^~!M_fo4PbtpD
+zKr9C)+?RC8PmO_rEXpBv6;(C*u8ZICKD;VCYiZoKe52D*1aC3LR(^km37Z^R6gM~Z
+ziPyeiDU4-Ku04NWe9Kp4a)3rHW2nyj(g_TR(%_%zcrS}^<Kt$|XD`n9aKFm+)gjAa
+zxH@DE#gxiL@)?54$|U3<BDL^Lh;a-+f|z3fmMq3ST$WEe`h^^wc8rJCFAA&GDlUF-
+zn&(G8Q{+>Y=DCWyq@@pynNtp&h%}E=J+n-aO!JWCX&Pn9!x0+J<NuhFS&~;SXK9{r
+zsFY9h1coM3yIEw}!-rJ=y|@?0aDcRjtglIjoQO-noR(*1zK>Qt_OW@oxXW~qFQO|)
+zC_1{FmR&wNILO|)=-^}r_~dz-$7VdIlNc1oap1lssY8boAR24l5Q%$GGnz%mF?&=h
+z4xL)s#t9th18vbtcM?S7j4n6UH&&Pmt+h*8;lbK^fr|#4yP~L3*jU-hDrv2?!L=Lf
+zjad=DB$K%yGC2q!Cove<V^p)wRb5|&voD!?op&F)K4dH$j{{v#1CWXiA~my6#Z=ep
+zl~hL57%=}#U~7=_xjQRd*${lLp*~~yU|Td7x9yA%e!htu=BcVBbV;eN<}lRjLts!5
+z=AA^<DyurjN+fPQPuJUW22|=S2V)4FUQ#WtqM$8pYpuY%7Y2g?uk1=eFnYv-DXed|
+z#FLBG&?>_qAPlx!0%smX_=a-GY?@<&!~hOva?o_fu#auvQ0Rw?jYyp}hcTpb(9i*L
+zXa=a#u>OaNhmwc^ZZU+y+U~){i#q~NVF#t#C>-$15%W91vFs+EDFzlv0SB%C#;`MF
+z_|9P{QUoo^_6#$>G{az=l*1UR6qI;eiif}ej(c7`F9($PU_23RNI@fy&79YAJu~JV
+zUiNjOOL!Kf9f$^CGbe|2G}@HIFtV0><$F$-*e|6B;F&1D?MZbhXAe>i)Ws54T$}4_
+z`Z5NzVO>hF&4Q8%Y9l=ZtOl4U9HnJaDupdknsSNv!V2_dZV#+ygS5w$wXNMtS7zOF
+z7=#=I2)^Bu9I&tep$Fw|)v7?P7UhuYQc>3fR0v}G0iN8NisF`7<4y1_lm%rw&=)NA
+zTn^B_mBMz5|5~l>?N-(hZNs@+f^W^_ATZ2rTH3>cE~RoHsJJAUbSj4>n{Jk&Zy5&Y
+z6=cFnv%-3xQKPlCbBUE-+BS-JGYpyL@1RSb22W(2^Sbm_@!_r*Xl#VV0FH<EQkgwu
+zHVt<K<`?Bqha7m3H|DC8F~e$}Eibby<S@g4K1}ja$lF8K|K#&<G$&E3fTbnBL_Jqg
+z#?;)4jmU$yWnBvNx+jA`>RVwCtUrR<5LZlF-~=|jOl&2Y&tyYL?LnFd+rvhqvDMhx
+z+G4O-Lkwbx6i?oe<{`o391p*%%QMh|9I7%tM8j1*jlH41Dt#*?A~%X)p5<WS(Uqea
+zXkL~keHRQ*V2y>3CA!Ft3xSXAVMAJP3$Llgv-#wFt6JrAJkIs1ns7yyJkB#t?gj3K
+z!5zXIDQMfY;5GyJC&UN5SS334p<%3DS3Rg%0tdCnB@B6seN5(Ab8E%xyU_s4Tf+CE
+zhD%n~8?YA+DJzA|i!gT)JaXOmL{bpD(|lMviD4m5XEt3$uCa=o%Nrtka1=m%0Hede
+z^l<1S<AMR_r8{Psu?THsgH0Da#|l=T{T0$75xYeLRw+RPVe+UP4A>zo^yaXZ(OY0J
+zz}(Cp(tL@=A(9}G3)OX#qaEZ>4@7<h2os0_WWagJGu>60G%~N5^>TyF?X@keFdeX#
+zND}dy<3mAOF$X;PhI*MyaZjcNcbZSP?;;1R<_trG0~V+UNC~~6GaNc*Bu)W3wQ@O9
+zy0S!uaGYF3#UTi1IiibH^T*^n?!r$AU;9`CsVQjCU`Swleb9np6$&k`-r1CuYl}WD
+zCx^GzrJP?9Gi0|O&Iq!6G%Xw1{l$Zgk!{Zl5Fm2iQK(QBgXzl74r0Xu?am8!cXk#5
+zprNpbG{aa(w{vp9`4Rp~7BoIA#WC-B$UtT#6=h+zd;MszS`4<1Ad8Dz!V2cQgnJ!h
+z*6v>9pg~g{=nEfzU?0Rpu!nl87_+hN=SAk;8|y8ZN-tQ){fxtHA%|27Z|s*sX|?b`
+za=QZ)W(>T4I6ckxK#+*csZTptP7a6<oM)$$(<RMuf&lwUka*yYR21=E^z?KY<||#$
+z#&();pK>rh%E$ykN-oXIVc`A$5)tqBb4^Y+`@v3Qt<jhp?CC}k+n#%j52u{r;ddJ~
+z=R^x14}b0lHABw^#o|wftOqslBOE6^z7}WLk8s)tI+ehX0(qbVKf=NApJpaT@%CKh
+zBjkB`Dk*}#0I^(mR=#I)0GPAF^D>{QDF}sHt~)E=sT_nwoE4sz`4n=H=5S_p3331o
+psZq=L&dN7)FA<zw-#W7gU^y%6zRc$tP4kvvoPVFMz}sJe{{eq`w(0-?
+
+diff --git a/MdeModulePkg/MdeModulePkg.dec b/MdeModulePkg/MdeModulePkg.dec
+index 58e6ab0048..b2b46546bd 100644
+--- a/MdeModulePkg/MdeModulePkg.dec
++++ b/MdeModulePkg/MdeModulePkg.dec
+@@ -1950,7 +1950,7 @@
+ 
+   ## Default OEM ID for ACPI table creation, its length must be 0x6 bytes to follow ACPI specification.
+   # @Prompt Default OEM ID for ACPI table creation.
+-  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemId|"INTEL "|VOID*|0x30001034
++  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemId|"AMAZON"|VOID*|0x30001034
+ 
+   ## Default OEM Table ID for ACPI table creation, it is "EDK2    ".
+   #  According to ACPI specification, this field is particularly useful when
+@@ -1958,7 +1958,7 @@
+   #  The OEM assigns each dissimilar table a new OEM Table ID.
+   #  This PCD is ignored for definition block.
+   # @Prompt Default OEM Table ID for ACPI table creation.
+-  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemTableId|0x20202020324B4445|UINT64|0x30001035
++  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemTableId|0x20204E4F5A414D41|UINT64|0x30001035
+ 
+   ## Default OEM Revision for ACPI table creation.
+   #  According to ACPI specification, for LoadTable() opcode, the OS can also

--- a/edk2-stable202211/0006-edk2-stable202211-efi-x86-Disable-disk-based-non-volatile-variable-store.patch
+++ b/edk2-stable202211/0006-edk2-stable202211-efi-x86-Disable-disk-based-non-volatile-variable-store.patch
@@ -1,0 +1,30 @@
+From 7d70dfe1831ddd37131dd123d0d1063f61e1dbf2 Mon Sep 17 00:00:00 2001
+From: Hendrik Borghorst <hborghor@amazon.de>
+Date: Fri, 2 Oct 2020 11:12:17 +0200
+Subject: [PATCH] efi/x86: Disable disk-based non-volatile variable store
+
+EDK2 has the nice option to have a disk-based store of the non-volatile
+variables. We definitely don't want the guest firmware to write on
+customer's disks.
+
+Signed-off-by: Hendrik Borghorst <hborghor@amazon.de>
+Reviewed-by: Evgeny Iakovlev <eyakovl@amazon.de>
+Reviewed-by: Alexander Graf (AWS) <graf@amazon.de>
+
+diff --git a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+index 98f6f07341..b9a86cba51 100644
+--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
++++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+@@ -1664,12 +1664,6 @@ PlatformBootManagerAfterConsole (
+       "PlatformBdsPolicyBehavior: not restoring NvVars "
+       "from disk since flash variables appear to be supported.\n"
+       ));
+-  } else {
+-    //
+-    // Try to restore variables from the hard disk early so
+-    // they can be used for the other BDS connect operations.
+-    //
+-    PlatformBdsRestoreNvVarsFromHardDisk ();
+   }
+ 
+   //

--- a/edk2-stable202211/0007-edk2-stable202211-uefi-Wipe-emulated-NvVariable-memory-on-allocation.patch
+++ b/edk2-stable202211/0007-edk2-stable202211-uefi-Wipe-emulated-NvVariable-memory-on-allocation.patch
@@ -1,0 +1,33 @@
+From d373f86a6a40a6293825ddec10a607e9a1e6d288 Mon Sep 17 00:00:00 2001
+From: Hendrik Borghorst <hborghor@amazon.de>
+Date: Fri, 16 Oct 2020 10:05:08 +0200
+Subject: [PATCH] uefi: Wipe emulated NvVariable memory on allocation
+
+EDK2 implements an emulation of non-volatile memory by keeping the data
+persistent over reboots. For now we don't want to persist data and
+provide a solution that is inline with the in-memory store of the .metal
+instances.
+
+This way we don't have to return EFI_UNSUPPORTED on SetVariable runtime
+service. This turned out to cause problems with Linux distribution's
+update routings (efibootmgr failing).
+
+Signed-off-by: Hendrik Borghorst <hborghor@amazon.de>
+Reviewed-by: Evgeny Iakovlev <eyakovl@amazon.de>
+Reviewed-by: Alexander Graf (AWS) <graf@amazon.de>
+
+diff --git a/OvmfPkg/Library/PlatformInitLib/Platform.c b/OvmfPkg/Library/PlatformInitLib/Platform.c
+index 2582689ffe..7b0a98cf24 100644
+--- a/OvmfPkg/Library/PlatformInitLib/Platform.c
++++ b/OvmfPkg/Library/PlatformInitLib/Platform.c
+@@ -767,6 +767,10 @@ PlatformReserveEmuVariableNvStore (
+     VarStoreSize / 1024
+     ));
+ 
++  // Clean variable space for now, as we don't want to persist variables over reboot
++  if (VariableStore != NULL)
++    SetMem((VOID *)VariableStore, VarStoreSize, 0x0);
++
+   return VariableStore;
+ }
+ 

--- a/edk2-stable202211/0008-edk2-stable202211-uefi-At-least-reserve-0xFFFF-bytes-for-SMBios-tables.patch
+++ b/edk2-stable202211/0008-edk2-stable202211-uefi-At-least-reserve-0xFFFF-bytes-for-SMBios-tables.patch
@@ -1,0 +1,41 @@
+From d6586de12373a42e860afa25147a1d66a672f2e3 Mon Sep 17 00:00:00 2001
+From: Hendrik Borghorst <hborghor@amazon.de>
+Date: Tue, 6 Oct 2020 16:06:06 +0200
+Subject: [PATCH] uefi: At least reserve 0xFFFF bytes for SMBios tables
+
+We expect to soon have DMI v2 tables with longer SMBios tables. Allocate
+0xFFFF (maximum of SMBios 2 tables) bytes so that no further change of
+memory layout is necessary. This reduces the risk of hibernation
+failures.
+
+Signed-off-by: Hendrik Borghorst <hborghor@amazon.de>
+Reviewed-by: Evgeny Iakovlev <eyakovl@amazon.de>
+Reviewed-by: Alexander Graf (AWS) <graf@amazon.de>
+
+diff --git a/MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.c b/MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.c
+index 1d43adc766..8a392a8f56 100644
+--- a/MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.c
++++ b/MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.c
+@@ -1172,10 +1172,12 @@ SmbiosCreateTable (
+     }
+ 
+     PhysicalAddress = 0xffffffff;
++    // Allocate at least the 64 KiB
++    UINT32 AllocateSize = EntryPointStructure->TableLength <= 0xFFFF ? 0xFFFF : EntryPointStructure->TableLength;
+     Status          = gBS->AllocatePages (
+                              AllocateMaxAddress,
+                              EfiRuntimeServicesData,
+-                             EFI_SIZE_TO_PAGES (EntryPointStructure->TableLength),
++                             EFI_SIZE_TO_PAGES (AllocateSize),
+                              &PhysicalAddress
+                              );
+     if (EFI_ERROR (Status)) {
+@@ -1184,7 +1186,7 @@ SmbiosCreateTable (
+       return EFI_OUT_OF_RESOURCES;
+     } else {
+       EntryPointStructure->TableAddress = (UINT32)PhysicalAddress;
+-      mPreAllocatedPages                = EFI_SIZE_TO_PAGES (EntryPointStructure->TableLength);
++      mPreAllocatedPages                = EFI_SIZE_TO_PAGES (AllocateSize);
+     }
+   }
+ 

--- a/edk2-stable202211/0009-edk2-stable202211-uefi-Disable-COM2-in-UEFI-to-prevent-it-from-being-used.patch
+++ b/edk2-stable202211/0009-edk2-stable202211-uefi-Disable-COM2-in-UEFI-to-prevent-it-from-being-used.patch
@@ -1,0 +1,32 @@
+From d589b317b5070405cab62d7c0e8e1d07134180e6 Mon Sep 17 00:00:00 2001
+From: Hendrik Borghorst <hborghor@amazon.de>
+Date: Wed, 7 Oct 2020 10:51:51 +0200
+Subject: [PATCH] uefi: Disable COM2 in UEFI to prevent it from being used
+
+Windows is using COM2 for debugging purposes, so prevent EDK2 from using
+it by not adding the device.
+
+Signed-off-by: Hendrik Borghorst <hborghor@amazon.de>
+Reviewed-by: Evgeny Iakovlev <eyakovl@amazon.de>
+Reviewed-by: Alexander Graf (AWS) <graf@amazon.de>
+
+diff --git a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+index b9a86cba51..ef3abe5b7a 100644
+--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
++++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+@@ -717,6 +717,7 @@ PrepareLpcBridgeDevicePath (
+   EfiBootManagerUpdateConsoleVariable (ConIn, DevicePath, NULL);
+   EfiBootManagerUpdateConsoleVariable (ErrOut, DevicePath, NULL);
+ 
++#if 0
+   //
+   // Register COM2
+   //
+@@ -754,6 +755,7 @@ PrepareLpcBridgeDevicePath (
+   EfiBootManagerUpdateConsoleVariable (ConOut, DevicePath, NULL);
+   EfiBootManagerUpdateConsoleVariable (ConIn, DevicePath, NULL);
+   EfiBootManagerUpdateConsoleVariable (ErrOut, DevicePath, NULL);
++#endif
+ 
+   return EFI_SUCCESS;
+ }

--- a/edk2-stable202211/0010-edk2-stable202211-uefi-Use-PPI-function-mask-for-user-confirmation.patch
+++ b/edk2-stable202211/0010-edk2-stable202211-uefi-Use-PPI-function-mask-for-user-confirmation.patch
@@ -1,0 +1,90 @@
+From ebc201cd413d43382dbe4686a67fb7d704ed1e81 Mon Sep 17 00:00:00 2001
+From: Sabin Rapan <sabrapan@amazon.com>
+Date: Fri, 21 May 2021 10:27:48 +0300
+Subject: [PATCH] uefi: Use PPI function mask for user confirmation
+
+... that we got from fwcfg instead of duplicating the logic.
+The function mask defines five values for each available function:
+1. Not implemented (0)
+2. Firmware only (1)
+3. Blocked (2)
+4. Allowed and requires user confirmation (3)
+5. Allowed and does not require user confirmation (4)
+
+Signed-off-by: Sabin Rapan <sabrapan@amazon.com>
+Reviewed-by: Petre Eftime <epetre@amazon.com>
+Reviewed-by: Laurentiu Stefan <stefala@amazon.com>
+
+diff --git a/OvmfPkg/Include/IndustryStandard/QemuTpm.h b/OvmfPkg/Include/IndustryStandard/QemuTpm.h
+index 1a269e6ad8..8bd8812a06 100644
+--- a/OvmfPkg/Include/IndustryStandard/QemuTpm.h
++++ b/OvmfPkg/Include/IndustryStandard/QemuTpm.h
+@@ -50,6 +50,7 @@ typedef struct {
+   UINT32    PpiAddress;
+   UINT8     TpmVersion;
+   UINT8     PpiVersion;
++  UINT8     PpiSuppFunc[256];
+ } QEMU_FWCFG_TPM_CONFIG;
+ #pragma pack ()
+ 
+diff --git a/OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.c b/OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.c
+index 4038020251..33a3d40eb1 100644
+--- a/OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.c
++++ b/OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.c
+@@ -132,21 +132,13 @@ QemuTpmInitPPI (
+     goto InvalidPpiAddress;
+   }
+ 
+-  for (Idx = 0; Idx < ARRAY_SIZE (mPpi->Func); Idx++) {
+-    mPpi->Func[Idx] = 0;
++  if (ARRAY_SIZE (mPpi->Func) != ARRAY_SIZE (Config.PpiSuppFunc)) {
++    DEBUG ((DEBUG_ERROR, "[TPM2PP] mPpi and Config.PpiSuppFunc have different sizes (%d vs %d)\n", ARRAY_SIZE (mPpi->Func), ARRAY_SIZE (Config.PpiSuppFunc)));
++    goto InvalidPpiAddress;
+   }
+ 
+-  if (Config.TpmVersion == QEMU_TPM_VERSION_2) {
+-    mPpi->Func[TCG2_PHYSICAL_PRESENCE_NO_ACTION]         = TPM_PPI_FLAGS;
+-    mPpi->Func[TCG2_PHYSICAL_PRESENCE_CLEAR]             = TPM_PPI_FLAGS;
+-    mPpi->Func[TCG2_PHYSICAL_PRESENCE_ENABLE_CLEAR]      = TPM_PPI_FLAGS;
+-    mPpi->Func[TCG2_PHYSICAL_PRESENCE_ENABLE_CLEAR_2]    = TPM_PPI_FLAGS;
+-    mPpi->Func[TCG2_PHYSICAL_PRESENCE_ENABLE_CLEAR_3]    = TPM_PPI_FLAGS;
+-    mPpi->Func[TCG2_PHYSICAL_PRESENCE_SET_PCR_BANKS]     = TPM_PPI_FLAGS;
+-    mPpi->Func[TCG2_PHYSICAL_PRESENCE_CHANGE_EPS]        = TPM_PPI_FLAGS;
+-    mPpi->Func[TCG2_PHYSICAL_PRESENCE_LOG_ALL_DIGESTS]   = TPM_PPI_FLAGS;
+-    mPpi->Func[TCG2_PHYSICAL_PRESENCE_ENABLE_BLOCK_SID]  = TPM_PPI_FLAGS;
+-    mPpi->Func[TCG2_PHYSICAL_PRESENCE_DISABLE_BLOCK_SID] = TPM_PPI_FLAGS;
++  for (Idx = 0; Idx < ARRAY_SIZE (mPpi->Func); Idx++) {
++    mPpi->Func[Idx] = Config.PpiSuppFunc[Idx];
+   }
+ 
+   if (mPpi->In == 0) {
+@@ -693,27 +685,9 @@ Tcg2HaveValidTpmRequest  (
+     }
+   }
+ 
+-  switch (mPpi->Request) {
+-    case TCG2_PHYSICAL_PRESENCE_NO_ACTION:
+-    case TCG2_PHYSICAL_PRESENCE_LOG_ALL_DIGESTS:
++  if (mPpi->Request < ARRAY_SIZE(mPpi->Func)) {
++    if (mPpi->Func[mPpi->Request] == QEMU_TPM_PPI_FUNC_ALLOWED_USR_NOT_REQ)
+       *RequestConfirmed = TRUE;
+-      return TRUE;
+-
+-    case TCG2_PHYSICAL_PRESENCE_CLEAR:
+-    case TCG2_PHYSICAL_PRESENCE_ENABLE_CLEAR:
+-    case TCG2_PHYSICAL_PRESENCE_ENABLE_CLEAR_2:
+-    case TCG2_PHYSICAL_PRESENCE_ENABLE_CLEAR_3:
+-    case TCG2_PHYSICAL_PRESENCE_SET_PCR_BANKS:
+-    case TCG2_PHYSICAL_PRESENCE_CHANGE_EPS:
+-    case TCG2_PHYSICAL_PRESENCE_ENABLE_BLOCK_SID:
+-    case TCG2_PHYSICAL_PRESENCE_DISABLE_BLOCK_SID:
+-      break;
+-
+-    default:
+-      //
+-      // Wrong Physical Presence command
+-      //
+-      return FALSE;
+   }
+ 
+   //

--- a/edk2-stable202211/0011-edk2-stable202211-OvmfPkg-Increase-PcdPciMmio64Size-to-16-TiB.patch
+++ b/edk2-stable202211/0011-edk2-stable202211-OvmfPkg-Increase-PcdPciMmio64Size-to-16-TiB.patch
@@ -1,0 +1,27 @@
+From 7ac1cafb5a326fd961dc5e94a8266426d09a9ddb Mon Sep 17 00:00:00 2001
+From: Nicolas Ojeda Leon <ncoleon@amazon.com>
+Date: Wed, 26 May 2021 17:57:40 +0200
+Subject: [PATCH] OvmfPkg: Increase PcdPciMmio64Size to 16 TiB
+
+Increased the 64-bit PCI aperture size PCD token to offer 16 TiB.
+The need to increase size beyond 32 GiB comes from platforms
+that having multiple GPUs, thus requiring more than 32 GiB
+high memory address space.
+
+Signed-off-by: Nicolas Ojeda Leon <ncoleon@amazon.com>
+Cc: Alexander Graf <graf@amazon.de>
+Cc: Hendrik Borghorst <hborghor@amazon.de>
+
+diff --git a/OvmfPkg/OvmfPkgX64.dsc b/OvmfPkg/OvmfPkgX64.dsc
+index 63c3a47aea..30bb110566 100644
+--- a/OvmfPkg/OvmfPkgX64.dsc
++++ b/OvmfPkg/OvmfPkgX64.dsc
+@@ -653,7 +653,7 @@
+ !ifdef $(CSM_ENABLE)
+   gUefiOvmfPkgTokenSpaceGuid.PcdPciMmio64Size|0x0
+ !else
+-  gUefiOvmfPkgTokenSpaceGuid.PcdPciMmio64Size|0x800000000
++  gUefiOvmfPkgTokenSpaceGuid.PcdPciMmio64Size|0x100000000000
+ !endif
+ 
+   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|0

--- a/edk2-stable202211/0012-edk2-stable202211-nitro-Add-ExtVarStore-for-vmm-based-variable-storage.patch
+++ b/edk2-stable202211/0012-edk2-stable202211-nitro-Add-ExtVarStore-for-vmm-based-variable-storage.patch
@@ -1,0 +1,851 @@
+From b7eb43ca09600ba534ecd220ab4aa546cf6f1fde Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Johanna=20Am=C3=A9lie=20Schander?= <mimoja@amazon.de>
+Date: Wed, 21 Apr 2021 15:12:39 +0200
+Subject: [PATCH] nitro: Add ExtVarStore for vmm based variable storage
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+To be able to process Variable Store requests outside of EDK2 we
+need to proxy the requests to the outside. This commit does this.
+The functions to the Runtime Table are overwriten and the Bootservice
+exit is hooked.
+As a word of warning: This code live in guest-accessible memory.
+All boundschecks here are best practice and can help debugging but
+are completely unsafe as they could be overwriten by the guest.
+
+CC: Deepak Gupta <dkgupta@amazon.com>
+CC: Hendrik Borghorst <hborghor@amazon.com>
+CC: Evgeny Iakovlev <eyakovl@amazon.com>
+
+Signed-off-by: Johanna Amélie Schander <mimoja@amazon.de>
+Signed-off-by: Hendrik Borghorst <hborghor@amazon.de>
+Reviewed-by: Evgeny Iakovlev <eyakovl@amazon.de>
+Reviewed-by: Alexander Graf (AWS) <graf@amazon.de>
+Reviewed-by: Sebastian Ott <sebott@amazon.de>
+
+diff --git a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+index 3858adf673..9f81e870f1 100644
+--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
++++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+@@ -70,7 +70,6 @@
+   HobLib
+   TpmMeasurementLib
+   AuthVariableLib
+-  VarCheckLib
+   VariableFlashInfoLib
+   VariablePolicyLib
+   VariablePolicyHelperLib
+diff --git a/OvmfPkg/OvmfPkgX64.dsc b/OvmfPkg/OvmfPkgX64.dsc
+index 30bb110566..615bbba40d 100644
+--- a/OvmfPkg/OvmfPkgX64.dsc
++++ b/OvmfPkg/OvmfPkgX64.dsc
+@@ -32,6 +32,7 @@
+   DEFINE SECURE_BOOT_ENABLE      = FALSE
+   DEFINE SMM_REQUIRE             = FALSE
+   DEFINE SOURCE_DEBUG_ENABLE     = FALSE
++  DEFINE EXTERNAL_VARIABLE_STORE = FALSE
+ 
+ !include OvmfPkg/OvmfTpmDefines.dsc.inc
+ 
+@@ -248,7 +249,9 @@
+ !else
+   AuthVariableLib|MdeModulePkg/Library/AuthVariableLibNull/AuthVariableLibNull.inf
+ !endif
++!if $(EXTERNAL_VARIABLE_STORE) == FALSE
+   VarCheckLib|MdeModulePkg/Library/VarCheckLib/VarCheckLib.inf
++!endif
+   VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.inf
+   VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
+   VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
+@@ -1087,6 +1090,9 @@
+   #
+   # Variable driver stack (non-SMM)
+   #
++  !if $(EXTERNAL_VARIABLE_STORE) == TRUE
++    nitro/ExtVarStore/ExtVarStore.inf
++  !else
+   OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesRuntimeDxe.inf
+   OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.inf {
+     <LibraryClasses>
+@@ -1097,6 +1103,7 @@
+     <LibraryClasses>
+       NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
+   }
++!endif
+ !endif
+ 
+   #
+diff --git a/OvmfPkg/OvmfPkgX64.fdf b/OvmfPkg/OvmfPkgX64.fdf
+index c0f5a1ef3c..68400549c5 100644
+--- a/OvmfPkg/OvmfPkgX64.fdf
++++ b/OvmfPkg/OvmfPkgX64.fdf
+@@ -223,9 +223,11 @@ APRIORI DXE {
+   # encrypted region (Since the range has not been marked shared/unencrypted).
+   INF  OvmfPkg/AmdSevDxe/AmdSevDxe.inf
+   INF  OvmfPkg/TdxDxe/TdxDxe.inf
++!if $(EXTERNAL_VARIABLE_STORE) == FALSE
+ !if $(SMM_REQUIRE) == FALSE
+   INF  OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesRuntimeDxe.inf
+ !endif
++!endif
+ }
+ 
+ #
+@@ -396,11 +398,15 @@ INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
+ #
+ # Variable driver stack (non-SMM)
+ #
++!if $(EXTERNAL_VARIABLE_STORE) == TRUE
++  INF nitro/ExtVarStore/ExtVarStore.inf
++!else
+ INF  OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesRuntimeDxe.inf
+ INF  OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.inf
+ INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
+ INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+ !endif
++!endif
+ 
+ #
+ # TPM support
+diff --git a/nitro/ExtVarStore/ExtVarStore.c b/nitro/ExtVarStore/ExtVarStore.c
+new file mode 100644
+index 0000000000..ade749c053
+--- /dev/null
++++ b/nitro/ExtVarStore/ExtVarStore.c
+@@ -0,0 +1,466 @@
++/** @file
++ *
++ * Proxies the Variable store RuntimeService to the host
++ *
++ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
++ * SPDX-License-Identifier: BSD-2-Clause-Patent
++ */
++
++#include <Library/BaseLib.h>
++#include <Library/BaseMemoryLib.h>
++#include <Library/DebugLib.h>
++#include <Library/UefiLib.h>
++#include <Library/SynchronizationLib.h>
++
++#include <Library/DxeServicesTableLib.h>
++#include <Library/UefiBootServicesTableLib.h>
++
++#include <PiDxe.h>
++
++#include <Library/BaseLib.h>
++#include <Library/PcdLib.h>
++#include <Library/BaseMemoryLib.h>
++#include <Library/MemoryAllocationLib.h>
++#include <Library/UefiBootServicesTableLib.h>
++#include <Library/UefiRuntimeLib.h>
++#include <Library/DebugLib.h>
++#include <Library/UefiLib.h>
++#include <Library/HobLib.h>
++#include <Library/DxeServicesTableLib.h>
++#include <Library/DevicePathLib.h>
++
++#include <Guid/VariableFormat.h>
++#include <Guid/GlobalVariable.h>
++#include <Protocol/Variable.h>
++#include <Protocol/VariableWrite.h>
++
++#include "interface.h"
++
++static EFI_EVENT mExtVirtualAddressChangeEvent = NULL;
++
++static SPIN_LOCK var_lock;
++
++static VOID *comm_buf_phys;
++VOID *comm_buf;
++
++STATIC
++EFI_STATUS
++EFIAPI
++ExtGetVariable (
++  IN      CHAR16            *VariableName,
++  IN      EFI_GUID          *VendorGuid,
++  OUT     UINT32            *Attributes OPTIONAL,
++  IN OUT  UINTN             *DataSize,
++  OUT     VOID              *Data OPTIONAL
++  )
++{
++  EFI_STATUS status;
++  UINT32 attr;
++  EFI_STATUS rc;
++
++  // Checks taken from FSVariable.c
++  if (VariableName == NULL || VendorGuid == NULL || DataSize == NULL) {
++    return EFI_INVALID_PARAMETER;
++  }
++
++  if (VariableName[0] == 0) {
++    return EFI_NOT_FOUND;
++  }
++
++  AcquireSpinLock(&var_lock);
++
++  uefi_param_buf buf = {
++    .buf = comm_buf,
++    .remaining = SHMEM_PAGES * EFI_PAGE_SIZE,
++  };
++
++  uefi_param_parser parser = {
++    .buf = buf,
++  };
++
++  uefi_param_writer writer = {
++  .buf = buf,
++  };
++
++  rc = serialize_uint32(&writer, VAR_STORE_VERSION);
++  rc |= serialize_command(&writer, COMMAND_GET_VARIABLE);
++  rc |= serialize_name(&writer, VariableName);
++  rc |= serialize_guid(&writer, VendorGuid);
++  rc |= serialize_uintn(&writer, *DataSize);
++
++  /* Serialization failure */
++  if (rc != EFI_SUCCESS)
++    goto out;
++
++  exec_command(comm_buf_phys);
++
++  rc = unserialize_result(&parser, &status);
++  if (rc != EFI_SUCCESS)
++    goto out;
++
++  switch (status) {
++  case EFI_SUCCESS:
++    rc = unserialize_uint32(&parser, &attr);
++    if (rc != EFI_SUCCESS)
++      goto out;
++    if (Attributes)
++      *Attributes = attr;
++    if (Data) {
++      rc = unserialize_data(&parser, Data, DataSize, *DataSize);
++      if (rc != EFI_SUCCESS)
++        goto out;
++    } else {
++      status = EFI_INVALID_PARAMETER;
++      goto out;
++    }
++    break;
++  case EFI_BUFFER_TOO_SMALL:
++    rc = unserialize_uintn(&parser, DataSize);
++    break;
++  default:
++    break;
++  }
++
++out:
++  ReleaseSpinLock(&var_lock);
++
++  /* Deserialization failure */
++  if (rc != EFI_SUCCESS) {
++    return EFI_DEVICE_ERROR;
++  }
++
++  return status;
++}
++
++STATIC
++EFI_STATUS
++EFIAPI
++ExtGetNextVariableName (
++  IN OUT  UINTN             *VariableNameSize,
++  IN OUT  CHAR16            *VariableName,
++  IN OUT  EFI_GUID          *VendorGuid
++  )
++{
++  EFI_STATUS status;
++  EFI_STATUS rc;
++
++  uefi_param_buf buf = {
++    .buf = comm_buf,
++    .remaining = SHMEM_PAGES * EFI_PAGE_SIZE,
++  };
++
++  uefi_param_parser parser = {
++    .buf = buf,
++  };
++
++  uefi_param_writer writer = {
++    .buf = buf,
++  };
++
++  if (!VariableNameSize || !VariableName || !VendorGuid)
++      return EFI_INVALID_PARAMETER;
++
++  if (StrSize(VariableName) > *VariableNameSize)
++      return EFI_INVALID_PARAMETER;
++
++  AcquireSpinLock(&var_lock);
++
++  rc = serialize_uint32(&writer, VAR_STORE_VERSION);
++  rc |= serialize_command(&writer, COMMAND_GET_NEXT_VARIABLE);
++  rc |= serialize_uintn(&writer, *VariableNameSize);
++  rc |= serialize_name(&writer, VariableName);
++  rc |= serialize_guid(&writer, VendorGuid);
++
++  /* Serialization failure */
++  if (rc != EFI_SUCCESS)
++    goto out;
++
++  exec_command(comm_buf_phys);
++
++  rc = unserialize_result(&parser, &status);
++  if (rc != EFI_SUCCESS)
++    goto out;
++
++  switch (status) {
++  case EFI_SUCCESS:
++    rc = unserialize_data(&parser, (UINT8*) VariableName, VariableNameSize, *VariableNameSize);
++    if (rc != EFI_SUCCESS)
++      goto out;
++    VariableName[*VariableNameSize / 2] = '\0';
++    *VariableNameSize += sizeof(*VariableName);
++    rc = unserialize_guid(&parser, VendorGuid);
++    if (rc != EFI_SUCCESS)
++      goto out;
++    break;
++  case EFI_BUFFER_TOO_SMALL:
++    rc = unserialize_uintn(&parser, VariableNameSize);
++    if (rc != EFI_SUCCESS)
++      goto out;
++    break;
++  default:
++    break;
++  }
++
++out:
++  ReleaseSpinLock(&var_lock);
++
++  /* Deserialization failure */
++  if (rc != EFI_SUCCESS) {
++    return EFI_DEVICE_ERROR;
++  }
++  return status;
++}
++
++
++STATIC
++EFI_STATUS
++EFIAPI
++ExtSetVariable (
++  IN CHAR16                  *VariableName,
++  IN EFI_GUID                *VendorGuid,
++  IN UINT32                  Attributes,
++  IN UINTN                   DataSize,
++  IN VOID                    *Data
++)
++{
++  EFI_STATUS status;
++  EFI_STATUS rc;
++
++  if (!VariableName || !VendorGuid)
++    return EFI_INVALID_PARAMETER;
++
++  if (!Data && DataSize != 0)
++    return EFI_INVALID_PARAMETER;
++
++  if (VariableName[0] == '\0')
++    return EFI_INVALID_PARAMETER;
++
++  uefi_param_buf buf = {
++    .buf = comm_buf,
++    .remaining = SHMEM_PAGES * EFI_PAGE_SIZE,
++  };
++
++  uefi_param_parser parser = {
++    .buf = buf,
++  };
++
++  uefi_param_writer writer = {
++    .buf = buf,
++  };
++
++  AcquireSpinLock(&var_lock);
++
++  rc = serialize_uint32(&writer, VAR_STORE_VERSION);
++  rc |= serialize_command(&writer, COMMAND_SET_VARIABLE);
++  rc |= serialize_name(&writer, VariableName);
++  rc |= serialize_guid(&writer, VendorGuid);
++  rc |= serialize_data(&writer, Data, DataSize);
++  rc |= serialize_uint32(&writer, Attributes);
++
++  /* Serialization failure */
++  if (rc != EFI_SUCCESS) {
++    ReleaseSpinLock(&var_lock);
++    return EFI_DEVICE_ERROR;
++  }
++
++  exec_command(comm_buf_phys);
++
++  rc = unserialize_result(&parser, &status);
++
++  ReleaseSpinLock(&var_lock);
++
++  /* Deserialization failure */
++  if (rc != EFI_SUCCESS) {
++    return EFI_DEVICE_ERROR;
++  }
++
++  return status;
++}
++
++
++STATIC
++EFI_STATUS
++EFIAPI
++ExtQueryVariableInfo (
++  IN  UINT32                 Attributes,
++  OUT UINT64                 *MaximumVariableStorageSize,
++  OUT UINT64                 *RemainingVariableStorageSize,
++  OUT UINT64                 *MaximumVariableSize
++  )
++{
++  EFI_STATUS status;
++  UINT64 temp;
++  EFI_STATUS rc;
++  uefi_param_buf buf = {
++    .buf = comm_buf,
++    .remaining = SHMEM_PAGES * EFI_PAGE_SIZE,
++  };
++
++  uefi_param_parser parser = {
++    .buf = buf,
++  };
++
++  uefi_param_writer writer = {
++    .buf = buf,
++  };
++
++  AcquireSpinLock(&var_lock);
++
++  rc = serialize_uint32(&writer, VAR_STORE_VERSION);
++  rc |= serialize_command(&writer, COMMAND_QUERY_VARIABLE_INFO);
++  rc |= serialize_uint32(&writer, Attributes);
++
++  /* Serialization failure */
++  if (rc != EFI_SUCCESS)
++    goto out;
++
++  exec_command(comm_buf_phys);
++
++  rc = unserialize_result(&parser, &status);
++  if (rc != EFI_SUCCESS)
++    goto out;
++
++  switch (status) {
++  case EFI_SUCCESS:
++    rc = unserialize_uint64(&parser, MaximumVariableStorageSize ? MaximumVariableStorageSize : &temp);
++    rc |= unserialize_uint64(&parser, RemainingVariableStorageSize ? RemainingVariableStorageSize : &temp);
++    rc |= unserialize_uint64(&parser, MaximumVariableSize ? MaximumVariableSize : &temp);
++    break;
++  default:
++    break;
++  }
++
++out:
++  ReleaseSpinLock(&var_lock);
++
++  /* Deserialization failure */
++  if (rc != EFI_SUCCESS) {
++    return EFI_DEVICE_ERROR;
++  }
++
++  return status;
++}
++
++
++VOID
++EFIAPI
++OnExitBootServices (
++  IN EFI_EVENT                               Event,
++  IN VOID                                    *Context
++  )
++{
++  EFI_STATUS rc;
++  uefi_param_buf buf = {
++    .buf = comm_buf,
++    .remaining = SHMEM_PAGES * EFI_PAGE_SIZE,
++  };
++
++  uefi_param_writer writer = {
++    .buf = buf,
++  };
++
++  AcquireSpinLock(&var_lock);
++
++  rc = serialize_uint32(&writer, VAR_STORE_VERSION);
++  rc |= serialize_command(&writer, COMMAND_ENTER_RUNTIME);
++
++  /* Serialization failure */
++  if (rc != EFI_SUCCESS) {
++    ReleaseSpinLock(&var_lock);
++    return;
++  }
++
++  // We dont care about the return value, we cannot do anything with it anyways
++  exec_command(comm_buf_phys);
++
++  ReleaseSpinLock(&var_lock);
++}
++
++
++STATIC
++VOID
++EFIAPI
++VariableClassAddressChangeEvent (
++  IN EFI_EVENT        Event,
++  IN VOID             *Context
++  )
++{
++  AcquireSpinLock(&var_lock);
++  /*
++   * Convert the comm_buf pointer from a physical to a virtual address for use
++   * at runtime.
++   */
++  EfiConvertPointer (0x0, (VOID **) &comm_buf);
++  ReleaseSpinLock(&var_lock);
++}
++
++/**
++ * The user Entry Point for the external variable store driver.
++ *
++ * @param[in]  ImageHandle    The firmware allocated handle for the EFI image.
++ * @param[in]  SystemTable    A pointer to the EFI System Table.
++ *
++ * @retval EFI_SUCCESS        The entry point is executed successfully.
++ * @retval EFI_UNSUPPORTED    Platform does not support the store.
++ * @retval Other              Some error occurs when executing this entry point.
++ *
++**/
++EFI_STATUS EFIAPI
++ExtVarStoreInit(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
++{
++  EFI_STATUS Status = EFI_SUCCESS;
++  EFI_EVENT ExitBootServiceEvent;
++
++  comm_buf_phys = AllocateRuntimePages(SHMEM_PAGES);
++  if (comm_buf_phys == NULL)
++    return EFI_OUT_OF_RESOURCES;
++  comm_buf = comm_buf_phys;
++
++  InitializeSpinLock(&var_lock);
++
++  // Taken from FSVariable.c
++  SystemTable->RuntimeServices->GetVariable         = ExtGetVariable;
++  SystemTable->RuntimeServices->GetNextVariableName = ExtGetNextVariableName;
++  SystemTable->RuntimeServices->SetVariable         = ExtSetVariable;
++  SystemTable->RuntimeServices->QueryVariableInfo   = ExtQueryVariableInfo;
++
++  //
++  // Install the Variable Runtime Architectural Protocol
++  //
++  Status = gBS->InstallMultipleProtocolInterfaces (
++                  &ImageHandle,
++                  &gEfiVariableArchProtocolGuid,
++                  NULL,
++                  &gEfiVariableWriteArchProtocolGuid,
++                  NULL,
++                  NULL);
++  ASSERT_EFI_ERROR (Status);
++
++  // Register the event when we need to remap on Runtime change
++  Status = gBS->CreateEventEx (
++                  EVT_NOTIFY_SIGNAL,
++                  TPL_NOTIFY,
++                  VariableClassAddressChangeEvent,
++                  NULL,
++                  &gEfiEventVirtualAddressChangeGuid,
++                  &mExtVirtualAddressChangeEvent
++                  );
++  ASSERT_EFI_ERROR (Status);
++
++  //
++  // Register the event to inform VMM variable store that it is at runtime.
++  // As we trust the initial guest payload to be customer trusted if it is signed
++  // we can trust on it not manipulating us (as it would decrease its own security)
++  //
++  Status = gBS->CreateEventEx (
++         EVT_NOTIFY_SIGNAL,
++         TPL_NOTIFY,
++         OnExitBootServices,
++         NULL,
++         &gEfiEventExitBootServicesGuid,
++         &ExitBootServiceEvent
++         );
++  ASSERT_EFI_ERROR (Status);
++
++  return Status;
++}
+diff --git a/nitro/ExtVarStore/ExtVarStore.inf b/nitro/ExtVarStore/ExtVarStore.inf
+new file mode 100644
+index 0000000000..62930e0e1c
+--- /dev/null
++++ b/nitro/ExtVarStore/ExtVarStore.inf
+@@ -0,0 +1,60 @@
++## @file
++#  Proxies the Variable store RuntimeService to the host
++#
++#  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
++#  SPDX-License-Identifier: BSD-2-Clause-Patent
++#
++##
++
++[Defines]
++  INF_VERSION                    = 0x00010005
++  BASE_NAME                      = ExtVarStore
++  FILE_GUID                      = 3984EE42-976A-46C5-8A64-23FB340035BC
++  MODULE_TYPE                    = DXE_RUNTIME_DRIVER
++  VERSION_STRING                 = 0.1
++  ENTRY_POINT                    = ExtVarStoreInit
++
++[Sources]
++  ExtVarStore.c
++  interface.h
++
++## Taken from VariableRuntimeDxe.inf
++[Packages]
++  MdePkg/MdePkg.dec
++  MdeModulePkg/MdeModulePkg.dec
++
++[LibraryClasses]
++  PcdLib
++  BaseMemoryLib
++  BaseLib
++  UefiBootServicesTableLib
++  UefiRuntimeLib
++  DebugLib
++  UefiLib
++  HobLib
++  DxeServicesTableLib
++  DevicePathLib
++  UefiDriverEntryPoint
++  MemoryAllocationLib
++  SynchronizationLib
++  PciLib
++
++[Guids]
++  gEfiEventExitBootServicesGuid                 ## CONSUMES ## Event
++  gEfiEventVirtualAddressChangeGuid             ## CONSUMES             ## Event
++  gEfiVariableGuid
++  gEfiGlobalVariableGuid                        ## PRODUCES ## Variable Guid
++
++[Protocols]
++  gEfiVariableArchProtocolGuid
++  gEfiVariableWriteArchProtocolGuid
++
++[Pcd]
++  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize
++  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxHardwareErrorVariableSize
++  gEfiMdeModulePkgTokenSpaceGuid.PcdVariableStoreSize
++  gEfiMdeModulePkgTokenSpaceGuid.PcdHwErrStorageSize
++##  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashVariablesEnable
++
++[Depex]
++  TRUE
+diff --git a/nitro/ExtVarStore/interface.h b/nitro/ExtVarStore/interface.h
+new file mode 100644
+index 0000000000..5225f07c9c
+--- /dev/null
++++ b/nitro/ExtVarStore/interface.h
+@@ -0,0 +1,197 @@
++/*
++ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
++ * SPDX-License-Identifier: BSD-2-Clause-Patent
++ */
++#pragma once
++
++#include <Library/BaseLib.h>
++#include <Library/DebugLib.h>
++#include <Library/IoLib.h>
++
++enum command_t {
++  COMMAND_GET_VARIABLE,
++  COMMAND_SET_VARIABLE,
++  COMMAND_GET_NEXT_VARIABLE,
++  COMMAND_QUERY_VARIABLE_INFO,
++  COMMAND_NOTIFY_SB_FAILURE,
++  COMMAND_ENTER_RUNTIME,
++};
++
++#define PORT_ADDRESS 0x0100
++#define SHMEM_PAGES  16
++
++#define VAR_STORE_VERSION 1
++
++typedef struct {
++	CHAR8 *buf;
++	UINTN remaining;
++} uefi_param_buf;
++
++typedef struct {
++	uefi_param_buf buf;
++} uefi_param_parser;
++
++typedef struct {
++	uefi_param_buf buf;
++} uefi_param_writer;
++
++static inline void uefi_param_buf_inc(uefi_param_buf *buf, UINTN size)
++{
++	buf->buf += size;
++	buf->remaining -= size;
++}
++
++static inline BOOLEAN uefi_param_buf_fits(uefi_param_buf *buf, UINTN size)
++{
++	return (buf->remaining >= size);
++}
++
++static inline EFI_STATUS
++uefi_parser_pop_head(uefi_param_parser *parser, void *data, UINTN size)
++{
++	uefi_param_buf *buf = &parser->buf;
++
++	if (!uefi_param_buf_fits(buf, size))
++	  return EFI_ABORTED;
++
++	CopyMem(data, buf->buf, size);
++	uefi_param_buf_inc(buf, size);
++	return EFI_SUCCESS;
++}
++
++static inline EFI_STATUS
++uefi_writer_push(uefi_param_writer *writer, void *data, UINTN size)
++{
++	uefi_param_buf *buf = &writer->buf;
++
++	if (!uefi_param_buf_fits(buf, size))
++	  return EFI_ABORTED;
++
++	CopyMem(buf->buf, data, size);
++	uefi_param_buf_inc(buf, size);
++	return EFI_SUCCESS;
++}
++
++static inline EFI_STATUS
++serialize_data(uefi_param_writer *writer, UINT8 *data, UINTN data_len)
++{
++	if (uefi_writer_push(writer, &data_len, sizeof(data_len)) != EFI_SUCCESS)
++	  return EFI_ABORTED;
++	if (uefi_writer_push(writer, data, data_len) != EFI_SUCCESS)
++	  return EFI_ABORTED;
++	return EFI_SUCCESS;
++}
++
++static inline EFI_STATUS serialize_result(uefi_param_writer *writer, EFI_STATUS status)
++{
++	return uefi_writer_push(writer, &status, sizeof(status));
++}
++
++static inline EFI_STATUS serialize_guid(uefi_param_writer *writer, EFI_GUID *guid)
++{
++	return uefi_writer_push(writer, (void *)guid, sizeof(EFI_GUID));
++}
++
++static inline EFI_STATUS serialize_timestamp(uefi_param_writer *writer, EFI_TIME *timestamp)
++{
++	return uefi_writer_push(writer, timestamp, sizeof(*timestamp));
++}
++
++static inline EFI_STATUS serialize_uintn(uefi_param_writer *writer, UINTN var)
++{
++	return uefi_writer_push(writer, &var, sizeof(var));
++}
++
++static inline EFI_STATUS serialize_uint32(uefi_param_writer *writer, UINT32 var)
++{
++	return uefi_writer_push(writer, &var, sizeof(var));
++}
++
++static inline EFI_STATUS serialize_command(uefi_param_writer *writer,
++				     enum command_t cmd)
++{
++	UINT32 data = (UINT32) cmd;
++	return serialize_uint32(writer, data);
++}
++
++static inline EFI_STATUS serialize_uint64(uefi_param_writer *writer, UINT64 var)
++{
++	return uefi_writer_push(writer, &var, sizeof(var));
++}
++
++static inline EFI_STATUS
++serialize_name(uefi_param_writer *writer, CHAR16 *VariableName)
++{
++	UINTN VarNameSize = StrLen(VariableName) * sizeof(*VariableName);
++	return serialize_data(writer, (UINT8*) VariableName, VarNameSize);
++}
++
++
++static inline EFI_STATUS unserialize_command(uefi_param_parser *parser,
++				       enum command_t *cmd)
++{
++	UINT32 data;
++	if (uefi_parser_pop_head(parser, &data, sizeof(data)) != EFI_SUCCESS)
++	  return EFI_ABORTED;
++
++	*cmd = (enum command_t)data;
++	return EFI_SUCCESS;
++}
++
++// Adjusted for Nitro to use static buffers
++static inline EFI_STATUS unserialize_data(uefi_param_parser *parser,
++					UINT8 *target_buffer,
++					UINTN *len,
++					UINTN limit)
++{
++	if (uefi_parser_pop_head(parser, len, sizeof(*len)) != EFI_SUCCESS)
++	  return EFI_ABORTED;
++	if (uefi_parser_pop_head(parser, target_buffer, *len) != EFI_SUCCESS)
++	  return EFI_ABORTED;
++
++	return EFI_SUCCESS;
++}
++
++static inline EFI_STATUS unserialize_guid(uefi_param_parser *parser, EFI_GUID *guid)
++{
++	return uefi_parser_pop_head(parser, guid, sizeof(EFI_GUID));
++}
++
++static inline EFI_STATUS unserialize_timestamp(uefi_param_parser *parser,
++					 EFI_TIME *timestamp)
++{
++	return uefi_parser_pop_head(parser, timestamp, sizeof(*timestamp));
++}
++
++static inline EFI_STATUS unserialize_uintn(uefi_param_parser *parser, UINTN *ret)
++{
++	return uefi_parser_pop_head(parser, ret, sizeof(*ret));
++}
++
++static inline EFI_STATUS unserialize_boolean(uefi_param_parser *parser, BOOLEAN *ret)
++{
++	return uefi_parser_pop_head(parser, ret, sizeof(*ret));
++}
++
++static inline EFI_STATUS unserialize_uint32(uefi_param_parser *parser, UINT32 *ret)
++{
++	return uefi_parser_pop_head(parser, ret, sizeof(*ret));
++}
++
++static inline EFI_STATUS unserialize_uint64(uefi_param_parser *parser, UINT64 *ret)
++{
++	return uefi_parser_pop_head(parser, ret, sizeof(*ret));
++}
++
++static inline EFI_STATUS unserialize_result(uefi_param_parser *parser, EFI_STATUS *status)
++{
++	return uefi_parser_pop_head(parser, status, sizeof(*status));
++}
++
++static inline void
++exec_command(VOID *buf)
++{
++  MemoryFence ();
++  IoWrite32 (PORT_ADDRESS, ((UINTN)buf) >> 12);
++  MemoryFence ();
++}

--- a/edk2-stable202211/0013-edk2-stable202211-Varstore-Use-MMIO-access-for-ARM.patch
+++ b/edk2-stable202211/0013-edk2-stable202211-Varstore-Use-MMIO-access-for-ARM.patch
@@ -1,0 +1,123 @@
+From 17246cdfce3e920cff52dcc58acb9d2e1e7c5510 Mon Sep 17 00:00:00 2001
+From: Alexander Graf <graf@amazon.com>
+Date: Wed, 12 May 2021 09:58:13 +0200
+Subject: [PATCH] Varstore: Use MMIO access for ARM
+
+On ARM, we want to use MMIO instead of PIO to notify the hypervisor. Adapt
+the code so that it uses MMIO on ARM.
+
+Signed-off-by: Alexander Graf <graf@amazon.com>
+Reviewed-by: Hendrik Borghorst <hborghor@amazon.de>
+Reviewed-by: Lav Joshi <lavjoshi@amazon.de>
+CC: Deepak Gupta <dkgupta@amazon.com>
+CC: Alexander Graf <graf@amazon.com>
+CC: David Woodhouse <dwmw@amazon.com>
+CC: Hendrik Borghorst <hborghor@amazon.com>
+CC: Saurav Sachidanand <sauravsc@amazon.com>
+
+diff --git a/nitro/ExtVarStore/ExtVarStore.c b/nitro/ExtVarStore/ExtVarStore.c
+index ade749c053..c2b0008c97 100644
+--- a/nitro/ExtVarStore/ExtVarStore.c
++++ b/nitro/ExtVarStore/ExtVarStore.c
+@@ -37,12 +37,27 @@
+ #include "interface.h"
+ 
+ static EFI_EVENT mExtVirtualAddressChangeEvent = NULL;
++#ifdef EXTVAR_MMIO_ADDRESS
++static UINTN mExtVarMMIO = EXTVAR_MMIO_ADDRESS;
++#endif
+ 
+ static SPIN_LOCK var_lock;
+ 
+ static VOID *comm_buf_phys;
+ VOID *comm_buf;
+ 
++static void
++exec_command(VOID *buf)
++{
++  MemoryFence ();
++#ifdef EXTVAR_MMIO_ADDRESS
++  MmioWrite64 (mExtVarMMIO, ((UINTN)buf) >> 12);
++#else
++  IoWrite32 (EXTVAR_PORT_ADDRESS, ((UINTN)buf) >> 12);
++#endif
++  MemoryFence ();
++}
++
+ STATIC
+ EFI_STATUS
+ EFIAPI
+@@ -391,6 +406,9 @@ VariableClassAddressChangeEvent (
+    * at runtime.
+    */
+   EfiConvertPointer (0x0, (VOID **) &comm_buf);
++#ifdef EXTVAR_MMIO_ADDRESS
++  EfiConvertPointer (0x0, (VOID **) &mExtVarMMIO);
++#endif
+   ReleaseSpinLock(&var_lock);
+ }
+ 
+@@ -416,6 +434,20 @@ ExtVarStoreInit(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
+     return EFI_OUT_OF_RESOURCES;
+   comm_buf = comm_buf_phys;
+ 
++#ifdef EXTVAR_MMIO_ADDRESS
++  Status = gDS->AddMemorySpace (
++      EfiGcdMemoryTypeMemoryMappedIo,
++      EXTVAR_MMIO_ADDRESS, EFI_PAGE_SIZE,
++      EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
++      );
++  ASSERT_EFI_ERROR (Status);
++
++  Status = gDS->SetMemorySpaceAttributes (
++      EXTVAR_MMIO_ADDRESS, EFI_PAGE_SIZE,
++      EFI_MEMORY_UC | EFI_MEMORY_RUNTIME);
++  ASSERT_EFI_ERROR (Status);
++#endif
++
+   InitializeSpinLock(&var_lock);
+ 
+   // Taken from FSVariable.c
+diff --git a/nitro/ExtVarStore/ExtVarStore.inf b/nitro/ExtVarStore/ExtVarStore.inf
+index 62930e0e1c..09c75ee5dd 100644
+--- a/nitro/ExtVarStore/ExtVarStore.inf
++++ b/nitro/ExtVarStore/ExtVarStore.inf
+@@ -37,6 +37,9 @@
+   UefiDriverEntryPoint
+   MemoryAllocationLib
+   SynchronizationLib
++  IoLib
++
++[LibraryClasses.X64]
+   PciLib
+ 
+ [Guids]
+diff --git a/nitro/ExtVarStore/interface.h b/nitro/ExtVarStore/interface.h
+index 5225f07c9c..eee9ae5c65 100644
+--- a/nitro/ExtVarStore/interface.h
++++ b/nitro/ExtVarStore/interface.h
+@@ -17,7 +17,11 @@ enum command_t {
+   COMMAND_ENTER_RUNTIME,
+ };
+ 
+-#define PORT_ADDRESS 0x0100
++#ifdef __aarch64__
++#define EXTVAR_MMIO_ADDRESS 0x09050000
++#else
++#define EXTVAR_PORT_ADDRESS 0x0100
++#endif
+ #define SHMEM_PAGES  16
+ 
+ #define VAR_STORE_VERSION 1
+@@ -187,11 +191,3 @@ static inline EFI_STATUS unserialize_result(uefi_param_parser *parser, EFI_STATU
+ {
+ 	return uefi_parser_pop_head(parser, status, sizeof(*status));
+ }
+-
+-static inline void
+-exec_command(VOID *buf)
+-{
+-  MemoryFence ();
+-  IoWrite32 (PORT_ADDRESS, ((UINTN)buf) >> 12);
+-  MemoryFence ();
+-}

--- a/edk2-stable202211/0014-edk2-stable202211-varstore-Read-feature-flags-from-VMM-over-PIO-MMIO.patch
+++ b/edk2-stable202211/0014-edk2-stable202211-varstore-Read-feature-flags-from-VMM-over-PIO-MMIO.patch
@@ -1,0 +1,291 @@
+From 81dfe89aa4228b9996e968ee1d05604a4d7f5861 Mon Sep 17 00:00:00 2001
+From: Hendrik Borghorst <hborghor@amazon.de>
+Date: Tue, 1 Jun 2021 17:12:56 +0200
+Subject: [PATCH] varstore: Read feature flags from VMM over PIO/MMIO
+
+This commit adds logic to fetch a 32bit feature flag value from the
+Hypervisor over the PIO that is also used to initiate the variable store
+commands.
+
+It reads a magic value and if it is correct it enable the new variable
+store for now.
+
+The existing variable store only gets enabled if no other variable
+store is active. If the new variable store should be activated and
+another one is already registered the CPU enters dead looping to prevent
+instance booting.
+
+In the future the feature flag might be extended to signal availability
+of certain features.
+
+Signed-off-by: Hendrik Borghorst <hborghor@amazon.de>
+Signed-off-by: Costin Lupu <lvpv@amazon.com>
+Reviewed-by: Evgeny Iakovlev <eyakovl@amazon.de>
+Reviewed-by: Alexander Graf (AWS) <graf@amazon.de>
+Reviewed-by: Sebastian Ott <sebott@amazon.de>
+
+diff --git a/CryptoPkg/Library/BaseCryptLib/SysCall/RuntimeMemAllocation.c b/CryptoPkg/Library/BaseCryptLib/SysCall/RuntimeMemAllocation.c
+index 0d2ca604ea..cf6f41f8c4 100644
+--- a/CryptoPkg/Library/BaseCryptLib/SysCall/RuntimeMemAllocation.c
++++ b/CryptoPkg/Library/BaseCryptLib/SysCall/RuntimeMemAllocation.c
+@@ -12,6 +12,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
+ #include <Library/UefiRuntimeLib.h>
+ #include <Library/MemoryAllocationLib.h>
+ #include <Guid/EventGroup.h>
++#include <Protocol/Variable.h>
+ 
+ // ----------------------------------------------------------------
+ // Initial version. Needs further optimizations.
+@@ -356,6 +357,17 @@ RuntimeCryptLibConstructor (
+   EFI_STATUS  Status;
+   VOID        *Buffer;
+ 
++  VOID *DummyProtocol;
++  Status = gBS->LocateProtocol (
++                &gEfiVariableArchProtocolGuid,
++                NULL,
++                (VOID **)&DummyProtocol);
++
++  // Abort if another variable store is already registered
++  if (Status == EFI_SUCCESS) {
++    return RETURN_SUCCESS;
++  }
++
+   //
+   // Pre-allocates runtime space for possible cryptographic operations
+   //
+diff --git a/MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLibNullClass.c b/MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLibNullClass.c
+index 9fbfd9df02..7e14b11d95 100644
+--- a/MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLibNullClass.c
++++ b/MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLibNullClass.c
+@@ -13,11 +13,13 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
+ #include <Library/BaseMemoryLib.h>
+ #include <Library/DebugLib.h>
+ #include <Library/DevicePathLib.h>
++#include <Library/UefiBootServicesTableLib.h>
+ 
+ #include <Guid/VariableFormat.h>
+ #include <Guid/GlobalVariable.h>
+ #include <Guid/HardwareErrorVariable.h>
+ #include <Guid/ImageAuthentication.h>
++#include <Protocol/Variable.h>
+ 
+ typedef
+ EFI_STATUS
+@@ -940,6 +942,19 @@ VarCheckUefiLibNullClassConstructor (
+   VOID
+   )
+ {
++  VOID *DummyProtocol;
++  EFI_STATUS Status;
++
++  Status = gBS->LocateProtocol (
++                &gEfiVariableArchProtocolGuid,
++                NULL,
++                (VOID **)&DummyProtocol);
++
++  // Abort if another variable store is already registered
++  if (Status == EFI_SUCCESS) {
++    return RETURN_SUCCESS;
++  }
++
+   VariablePropertySetUefiDefined ();
+   VarCheckLibRegisterSetVariableCheckHandler (SetVariableCheckHandlerUefiDefined);
+ 
+diff --git a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableDxe.c b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableDxe.c
+index d5c409c914..55e0f0533b 100644
+--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableDxe.c
++++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableDxe.c
+@@ -542,6 +542,16 @@ VariableServiceInitialize (
+   EFI_EVENT   ReadyToBootEvent;
+   EFI_EVENT   EndOfDxeEvent;
+ 
++  VOID *DummyProtocol;
++  Status = gBS->LocateProtocol (
++                &gEfiVariableArchProtocolGuid,
++                NULL,
++                (VOID **)&DummyProtocol);
++
++  // Abort if another variable store is already registered
++  if (Status == EFI_SUCCESS)
++    return EFI_UNSUPPORTED;
++
+   Status = VariableCommonInitialize ();
+   ASSERT_EFI_ERROR (Status);
+ 
+diff --git a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+index 9f81e870f1..3858adf673 100644
+--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
++++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+@@ -70,6 +70,7 @@
+   HobLib
+   TpmMeasurementLib
+   AuthVariableLib
++  VarCheckLib
+   VariableFlashInfoLib
+   VariablePolicyLib
+   VariablePolicyHelperLib
+diff --git a/OvmfPkg/OvmfPkgX64.dsc b/OvmfPkg/OvmfPkgX64.dsc
+index 615bbba40d..1b3540a86b 100644
+--- a/OvmfPkg/OvmfPkgX64.dsc
++++ b/OvmfPkg/OvmfPkgX64.dsc
+@@ -249,9 +249,7 @@
+ !else
+   AuthVariableLib|MdeModulePkg/Library/AuthVariableLibNull/AuthVariableLibNull.inf
+ !endif
+-!if $(EXTERNAL_VARIABLE_STORE) == FALSE
+   VarCheckLib|MdeModulePkg/Library/VarCheckLib/VarCheckLib.inf
+-!endif
+   VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.inf
+   VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
+   VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
+@@ -1090,9 +1088,12 @@
+   #
+   # Variable driver stack (non-SMM)
+   #
++  # ### WARNING ###
++  # Don't change the order of ExtVarStore.inf. It defines the initialization
++  # order of the variable stores.
+   !if $(EXTERNAL_VARIABLE_STORE) == TRUE
+     nitro/ExtVarStore/ExtVarStore.inf
+-  !else
++  !endif
+   OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesRuntimeDxe.inf
+   OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.inf {
+     <LibraryClasses>
+@@ -1103,7 +1104,6 @@
+     <LibraryClasses>
+       NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
+   }
+-!endif
+ !endif
+ 
+   #
+diff --git a/OvmfPkg/OvmfPkgX64.fdf b/OvmfPkg/OvmfPkgX64.fdf
+index 68400549c5..5fcf7e9c51 100644
+--- a/OvmfPkg/OvmfPkgX64.fdf
++++ b/OvmfPkg/OvmfPkgX64.fdf
+@@ -398,15 +398,17 @@ INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
+ #
+ # Variable driver stack (non-SMM)
+ #
++# ### WARNING ###
++# Don't change the order of ExtVarStore.inf. It defines the initialization
++# order of the variable stores.
+ !if $(EXTERNAL_VARIABLE_STORE) == TRUE
+   INF nitro/ExtVarStore/ExtVarStore.inf
+-!else
++!endif
+ INF  OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesRuntimeDxe.inf
+ INF  OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.inf
+ INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
+ INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+ !endif
+-!endif
+ 
+ #
+ # TPM support
+diff --git a/nitro/ExtVarStore/ExtVarStore.c b/nitro/ExtVarStore/ExtVarStore.c
+index c2b0008c97..0b4aa0a07f 100644
+--- a/nitro/ExtVarStore/ExtVarStore.c
++++ b/nitro/ExtVarStore/ExtVarStore.c
+@@ -58,6 +58,19 @@ exec_command(VOID *buf)
+   MemoryFence ();
+ }
+ 
++static UINT32 read_interface()
++{
++  UINT32 value;
++  MemoryFence ();
++#ifdef EXTVAR_MMIO_ADDRESS
++  value = MmioRead32 (mExtVarMMIO);
++#else
++  value = IoRead32 (EXTVAR_PORT_ADDRESS);
++#endif
++  MemoryFence ();
++  return value;
++}
++
+ STATIC
+ EFI_STATUS
+ EFIAPI
+@@ -412,6 +425,20 @@ VariableClassAddressChangeEvent (
+   ReleaseSpinLock(&var_lock);
+ }
+ 
++STATIC
++EFI_STATUS
++read_feature_flags()
++{
++  /* Check for magic value before parsing the flags */
++  UINT32 value = read_interface ();
++  struct feature_word *features = (struct feature_word *)&value;
++
++  if (features->magic_value != VAR_STORE_MAGIC_VALUE)
++    return EFI_UNSUPPORTED;
++
++  return EFI_SUCCESS;
++}
++
+ /**
+  * The user Entry Point for the external variable store driver.
+  *
+@@ -429,11 +456,6 @@ ExtVarStoreInit(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
+   EFI_STATUS Status = EFI_SUCCESS;
+   EFI_EVENT ExitBootServiceEvent;
+ 
+-  comm_buf_phys = AllocateRuntimePages(SHMEM_PAGES);
+-  if (comm_buf_phys == NULL)
+-    return EFI_OUT_OF_RESOURCES;
+-  comm_buf = comm_buf_phys;
+-
+ #ifdef EXTVAR_MMIO_ADDRESS
+   Status = gDS->AddMemorySpace (
+       EfiGcdMemoryTypeMemoryMappedIo,
+@@ -448,6 +470,25 @@ ExtVarStoreInit(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
+   ASSERT_EFI_ERROR (Status);
+ #endif
+ 
++  if (read_feature_flags() != EFI_SUCCESS)
++    return EFI_UNSUPPORTED;
++
++  comm_buf_phys = AllocateRuntimePages(SHMEM_PAGES);
++  if (comm_buf_phys == NULL)
++    return EFI_OUT_OF_RESOURCES;
++  comm_buf = comm_buf_phys;
++
++  /* Check if a driver already registered, that should not happen */
++  VOID *DummyProtocol;
++  Status = gBS->LocateProtocol (
++                &gEfiVariableArchProtocolGuid,
++                NULL,
++                (VOID **)&DummyProtocol);
++
++  /* Dead loop the CPU if another variable store is already registered */
++  if (Status == EFI_SUCCESS) {
++    CpuDeadLoop();
++  }
+   InitializeSpinLock(&var_lock);
+ 
+   // Taken from FSVariable.c
+diff --git a/nitro/ExtVarStore/interface.h b/nitro/ExtVarStore/interface.h
+index eee9ae5c65..87d3d8ae31 100644
+--- a/nitro/ExtVarStore/interface.h
++++ b/nitro/ExtVarStore/interface.h
+@@ -26,6 +26,16 @@ enum command_t {
+ 
+ #define VAR_STORE_VERSION 1
+ 
++/**
++ * Magic value that needs to be in sync with EDK2 var store.
++ */
++#define VAR_STORE_MAGIC_VALUE 0xec
++
++struct feature_word {
++  UINT8 magic_value;
++  UINT32 features:24;
++} _packed;
++
+ typedef struct {
+ 	CHAR8 *buf;
+ 	UINTN remaining;

--- a/edk2-stable202211/0015-edk2-stable202211-arm-x86-Enable-Nitro-external-variable-store.patch
+++ b/edk2-stable202211/0015-edk2-stable202211-arm-x86-Enable-Nitro-external-variable-store.patch
@@ -1,0 +1,29 @@
+From b8f386feb2a9492480214d79074768dde855da57 Mon Sep 17 00:00:00 2001
+From: Hendrik Borghorst <hborghor@amazon.de>
+Date: Thu, 24 Jun 2021 12:16:06 +0200
+Subject: [PATCH] arm/x86: Enable Nitro external variable store
+
+Start including the Nitro-based variable store that is able to
+persist variables.
+
+Signed-off-by: Hendrik Borghorst <hborghor@amazon.de>
+Reviewed-by: Evgeny Iakovlev <eyakovl@amazon.de>
+Reviewed-by: Sebastian Ott <sebott@amazon.de>
+
+diff --git a/OvmfPkg/OvmfPkgX64.dsc b/OvmfPkg/OvmfPkgX64.dsc
+index 1b3540a86b..190505ba3a 100644
+--- a/OvmfPkg/OvmfPkgX64.dsc
++++ b/OvmfPkg/OvmfPkgX64.dsc
+@@ -29,10 +29,10 @@
+   # Defines for default states.  These can be changed on the command line.
+   # -D FLAG=VALUE
+   #
+-  DEFINE SECURE_BOOT_ENABLE      = FALSE
++  DEFINE SECURE_BOOT_ENABLE      = TRUE
+   DEFINE SMM_REQUIRE             = FALSE
+   DEFINE SOURCE_DEBUG_ENABLE     = FALSE
+-  DEFINE EXTERNAL_VARIABLE_STORE = FALSE
++  DEFINE EXTERNAL_VARIABLE_STORE = TRUE
+ 
+ !include OvmfPkg/OvmfTpmDefines.dsc.inc
+ 

--- a/edk2-stable202211/0016-edk2-stable202211-x86-Use-simple-emulated-variable-store-instead-of-RAM-persistent.patch
+++ b/edk2-stable202211/0016-edk2-stable202211-x86-Use-simple-emulated-variable-store-instead-of-RAM-persistent.patch
@@ -1,0 +1,80 @@
+From 89f7626324077b308f831b678f617aa174b65c14 Mon Sep 17 00:00:00 2001
+From: Hendrik Borghorst <hborghor@amazon.de>
+Date: Wed, 30 Jun 2021 16:42:01 +0200
+Subject: [PATCH] x86: Use simple emulated variable store instead of RAM
+ persistent
+
+The ovmf package provides a variable store that is emulating a
+flash-based persistence storage for UEFI variable inside the RAM. On
+reboot the RAM is persisted so that variables are not reset.
+
+Nitro has no need for that feature and manually wiped the emulated
+store on reboot with a previous commit enabling us, to keep certain
+variables in the future. The feature was never used.
+
+Now that we are offering the persistent variable soon over Nitro
+itself we can just use the RAM-based variable store that has no
+persistence. The same store is already used for ARM instances.
+
+Testing done:
+- Boot Ubuntu Groovy instance
+- Boot Windows 2016 and 2019
+- Remove all boot entries in Ubuntu with efibootmgr and reboot
+successfully.
+
+- Boot with old Fvb-variable store, remove all variables in guest, LU to
+new Nitro with new var store, reboot guest, check variables are
+repopulated: Works
+- Boot with new variable store, remove all variables in guest, LU to old
+Fvb-based variable store, reboot guest, check variables are repopulated:
+Works
+
+Signed-off-by: Hendrik Borghorst <hborghor@amazon.de>
+Signed-off-by: Sabin Rapan <sabrapan@amazon.com>
+Signed-off-by: Costin Lupu <lvpv@amazon.com>
+Reviewed-by: Adamos Ttofari <attofari@amazon.de>
+Reviewed-by: Evgeny Iakovlev <eyakovl@amazon.de>
+Reviewed-by: Lav Joshi <lavjoshi@amazon.de>
+
+diff --git a/OvmfPkg/OvmfPkgX64.dsc b/OvmfPkg/OvmfPkgX64.dsc
+index 190505ba3a..c26832dd43 100644
+--- a/OvmfPkg/OvmfPkgX64.dsc
++++ b/OvmfPkg/OvmfPkgX64.dsc
+@@ -630,6 +630,7 @@
+ [PcdsDynamicDefault]
+   # only set when
+   #   ($(SMM_REQUIRE) == FALSE)
++  gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable|TRUE
+   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved|0
+ 
+ !if $(SMM_REQUIRE) == FALSE
+@@ -1094,12 +1095,6 @@
+   !if $(EXTERNAL_VARIABLE_STORE) == TRUE
+     nitro/ExtVarStore/ExtVarStore.inf
+   !endif
+-  OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesRuntimeDxe.inf
+-  OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.inf {
+-    <LibraryClasses>
+-      PlatformFvbLib|OvmfPkg/Library/EmuVariableFvbLib/EmuVariableFvbLib.inf
+-  }
+-  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
+   MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf {
+     <LibraryClasses>
+       NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
+diff --git a/OvmfPkg/OvmfPkgX64.fdf b/OvmfPkg/OvmfPkgX64.fdf
+index 5fcf7e9c51..1c59d58970 100644
+--- a/OvmfPkg/OvmfPkgX64.fdf
++++ b/OvmfPkg/OvmfPkgX64.fdf
+@@ -404,10 +404,8 @@ INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
+ !if $(EXTERNAL_VARIABLE_STORE) == TRUE
+   INF nitro/ExtVarStore/ExtVarStore.inf
+ !endif
+-INF  OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesRuntimeDxe.inf
+-INF  OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.inf
+-INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
+-INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
++# Nitro: We use the Xen VariableRuntimeDxe.inf to eliminate flash
++INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+ !endif
+ 
+ #

--- a/edk2-stable202211/0017-edk2-stable202211-pci-Touch-each-page-when-mapped-for-IO.patch
+++ b/edk2-stable202211/0017-edk2-stable202211-pci-Touch-each-page-when-mapped-for-IO.patch
@@ -1,0 +1,55 @@
+From 3dbda6dc52d909d78961533530fbc2e4fcb802e5 Mon Sep 17 00:00:00 2001
+From: James Gowans <jgowans@amazon.com>
+Date: Mon, 3 May 2021 15:52:43 +0100
+Subject: [PATCH] pci: Touch each page when mapped for IO
+
+This functionality is required for memory oversubscription: the instance
+needs to make DMA-able pages resident before initiating a DMA
+transaction. Once the kernel is booted, the ppIOMMU driver takes care of
+this. However, before the kernel has booted, EDK2 will be doing DMA, and
+hence it needs to ensure that the target pages are DMA-able.
+
+Much like how the ppIOMMU hooks into dma_map_ops, this patch adds some
+instructions to the function which is invoked when UEFI makes memory
+region DMA-able to touch all pages in the region.
+
+This patch doesn't attempt to differentiate overcommit vs
+non-overcommit: the functionality of touches pages before DMA will be
+done for all EC2 instances. The reason just to keep stuff simple:
+although non-overcommit instances have no use for this functionality the
+overhead is low enough that it's okay to do it always.
+
+Signed-off-by: James Gowans <jgowans@amazon.com>
+Reviewed-by: Alan Powell <alpowell@amazon.com>
+Reviewed-by: Roland Paterson-Jones <rolandp@amazon.com>
+
+diff --git a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+index 157a0ada80..51aa6986dc 100644
+--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
++++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+@@ -7,6 +7,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
+ 
+ **/
+ 
++#include <Library/IoLib.h>
+ #include "PciHostBridge.h"
+ #include "PciRootBridge.h"
+ #include "PciHostResource.h"
+@@ -1331,6 +1332,7 @@ RootBridgeIoMap (
+   PCI_ROOT_BRIDGE_INSTANCE  *RootBridge;
+   EFI_PHYSICAL_ADDRESS      PhysicalAddress;
+   MAP_INFO                  *MapInfo;
++  UINTN                     PageTouchOffset;
+ 
+   if ((HostAddress == NULL) || (NumberOfBytes == NULL) || (DeviceAddress == NULL) ||
+       (Mapping == NULL))
+@@ -1347,6 +1349,9 @@ RootBridgeIoMap (
+ 
+   RootBridge = ROOT_BRIDGE_FROM_THIS (This);
+ 
++  for (PageTouchOffset = 0; PageTouchOffset < *NumberOfBytes; PageTouchOffset += EFI_PAGE_SIZE)
++    MmioRead8((UINTN) HostAddress + PageTouchOffset);
++
+   if (mIoMmu != NULL) {
+     if (!RootBridge->DmaAbove4G) {
+       //

--- a/edk2-stable202211/0018-edk2-stable202211-Image-SecureBoot-Write-the-last-secureboot-status-into-a-variable.patch
+++ b/edk2-stable202211/0018-edk2-stable202211-Image-SecureBoot-Write-the-last-secureboot-status-into-a-variable.patch
@@ -1,0 +1,70 @@
+From 41dd109a520c96d11652cf1c0e05c2aa02632452 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Johanna=20Am=C3=A9lie=20Schander?= <mimoja@amazon.de>
+Date: Thu, 23 Sep 2021 16:48:04 +0200
+Subject: [PATCH] Image/SecureBoot: Write the last secureboot status into a
+ variable
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Right now we do not get notified if the guest fails to boot an image,
+to change this we are extending the interface between the varstore
+implementation and EDK2.
+
+Due to the package system of EDK2 we cannot easily call the ExtVarStore
+directly on ABI level. The alternative of extending the SystemTables
+RuntimeSerices would expose the functionality directly to the guest
+which might not be able to use it properly. While there is an EDK2
+extension to the RuntimeTables the effort outweights the benefits here.
+We are therefore creating a new Variable with the latest Image loading
+result.
+
+Upstream-status:
+Not posting upstream as the solution is custom tailored to the nitro
+variable store whichout this commit is worthless. The upstreamable
+solution would be to use the EDK2 reuntime table extensions which is
+not done here as explained in the commit itself.
+
+Signed-off-by: Johanna Amélie Schander <mimoja@amazon.de>
+Reviewed-by: Hendrik Borghorst <hborghor@amazon.de>
+Reviewed-by: Saurav Sachidanand <sauravsc@amazon.de>
+
+diff --git a/MdeModulePkg/Core/Dxe/Image/Image.c b/MdeModulePkg/Core/Dxe/Image/Image.c
+index 06cc6744b8..ed1e883883 100644
+--- a/MdeModulePkg/Core/Dxe/Image/Image.c
++++ b/MdeModulePkg/Core/Dxe/Image/Image.c
+@@ -1089,6 +1089,25 @@ CoreUnloadAndCloseImage (
+   CoreFreePool (Image);
+ }
+ 
++/**
++ * Notify the variable store about issues with the boot image
++ * 
++ */
++static
++EFI_STATUS
++NotifySecureBootStatus(EFI_STATUS status)
++{
++  EFI_STATUS res = gDxeCoreRT->SetVariable(
++                          L"X-Nitro-SecurebootStatus",
++                          &gEfiGlobalVariableGuid,
++                          EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS,
++                          sizeof(status),
++                          (VOID *) &status
++                          );
++
++  return res;
++}
++
+ /**
+   Loads an EFI image into memory and returns a handle to the image.
+ 
+@@ -1304,6 +1323,8 @@ CoreLoadImageCommon (
+                                   );
+   }
+ 
++  NotifySecureBootStatus(SecurityStatus);
++
+   //
+   // Check Security Status.
+   //

--- a/edk2-stable202211/0019-edk2-stable202211-BDS-Only-call-the-uefi-shell-as-last-resort.patch
+++ b/edk2-stable202211/0019-edk2-stable202211-BDS-Only-call-the-uefi-shell-as-last-resort.patch
@@ -1,0 +1,158 @@
+From b6c53800d20eea193b28a5f92fa0445a7ce26761 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Johanna=20Am=C3=A9lie=20Schander?= <mimoja@amazon.de>
+Date: Mon, 28 Feb 2022 13:15:56 +0100
+Subject: [PATCH] BDS: Only call the uefi shell as last resort
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When we are not able to boot one of the Boot Entries the Ovmf Package
+defaults to the UEFI shell by adding it to the BootOrder.
+Customers, who might have misconfigured their BootOrder in some
+way or another (e.g. via a rootdevice replacement or a snapshot restore)
+will therefore be dropped into a UEFI shell instead of beeing booted
+the removable device path that the current implementation of UEFI
+in the EC2 fleet boots.
+
+By removing the UEFI shell entry BDS will now scan for the removable paths
+when all BootEntries have failed. If this also fails we manually start the EFI
+Shell and reset the instance if that also fails or is exited.
+
+Upstream-status: Not applicable
+
+Signed-off-by: Johanna Amélie Schander <mimoja@amazon.de>
+Reviewed-by: Alexander Graf (AWS) <graf@amazon.de>
+Reviewed-by: Hendrik Borghorst <hborghor@amazon.de>
+CC: Alex Graf <graf@amazon.com>
+CC: Hendrik Borghorst <hborghor@amazon.com>
+
+diff --git a/MdeModulePkg/Universal/BdsDxe/BdsDxe.inf b/MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
+index 5bac635def..29089dcea1 100644
+--- a/MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
++++ b/MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
+@@ -37,6 +37,7 @@
+ [Packages]
+   MdePkg/MdePkg.dec
+   MdeModulePkg/MdeModulePkg.dec
++  ShellPkg/ShellPkg.dec
+ 
+ [LibraryClasses]
+   DevicePathLib
+@@ -74,6 +75,7 @@
+   gConnectConInEventGuid                        ## SOMETIMES_CONSUMES ## Event
+   gEdkiiStatusCodeDataTypeVariableGuid          ## SOMETIMES_CONSUMES ## GUID
+   gEfiEventReadyToBootGuid                      ## CONSUMES           ## Event
++  gUefiShellFileGuid                            ## SOMETIMES_CONSUMES
+ 
+ [Protocols]
+   gEfiBdsArchProtocolGuid                       ## PRODUCES
+diff --git a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+index 766dde3aae..33db648c68 100644
+--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
++++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+@@ -656,6 +656,49 @@ BdsFormalizeEfiGlobalVariable (
+   BdsFormalizeOSIndicationVariable ();
+ }
+ 
++STATIC
++EFI_STATUS
++GetFvLoadOption (
++  EFI_GUID                         *FileGuid,
++  EFI_BOOT_MANAGER_LOAD_OPTION     *NewOption
++  )
++{
++  EFI_STATUS                        Status;
++  MEDIA_FW_VOL_FILEPATH_DEVICE_PATH FileNode;
++  EFI_LOADED_IMAGE_PROTOCOL         *LoadedImage;
++  EFI_DEVICE_PATH_PROTOCOL          *DevicePath;
++
++  Status = gBS->HandleProtocol (
++                  gImageHandle,
++                  &gEfiLoadedImageProtocolGuid,
++                  (VOID **) &LoadedImage
++                  );
++  ASSERT_EFI_ERROR (Status);
++
++  EfiInitializeFwVolDevicepathNode (&FileNode, FileGuid);
++  DevicePath = DevicePathFromHandle (LoadedImage->DeviceHandle);
++  ASSERT (DevicePath != NULL);
++  DevicePath = AppendDevicePathNode (
++                 DevicePath,
++                 (EFI_DEVICE_PATH_PROTOCOL *) &FileNode
++                 );
++  ASSERT (DevicePath != NULL);
++
++  Status = EfiBootManagerInitializeLoadOption (
++             NewOption,
++             LoadOptionNumberUnassigned,
++             LoadOptionTypeBoot,
++             LOAD_OPTION_ACTIVE,
++             L"Internal FV Binary",
++             DevicePath,
++             NULL,
++             0
++             );
++  ASSERT_EFI_ERROR (Status);
++  FreePool (DevicePath);
++  return Status;
++}
++
+ /**
+ 
+   Service routine for BdsInstance->Entry(). Devices are connected, the
+@@ -691,6 +734,7 @@ BdsEntry (
+   EFI_DEVICE_PATH_PROTOCOL        *FilePath;
+   EFI_STATUS                      BootManagerMenuStatus;
+   EFI_BOOT_MANAGER_LOAD_OPTION    PlatformDefaultBootOption;
++  EFI_BOOT_MANAGER_LOAD_OPTION    BootEfiShell;
+ 
+   HotkeyTriggered = NULL;
+   Status          = EFI_SUCCESS;
+@@ -1112,6 +1156,27 @@ BdsEntry (
+     }
+   }
+ 
++  // Get the Uefi Shell boot entry
++  Status = GetFvLoadOption (
++    &gUefiShellFileGuid,
++    &BootEfiShell
++  );
++
++  if (Status == EFI_SUCCESS) {
++    AsciiPrint (
++      "No bootable option or device was found.\n"
++      "Dropping to the EFI Shell.\n"
++      "Exiting the UEFI shell will restart the system"
++    );
++
++    EfiBootManagerBoot (&BootEfiShell);
++
++    // If we can not drop into the Efi Shell or the shell exited reset
++    gRT->ResetSystem (EfiResetWarm, EFI_SUCCESS, 0, NULL);
++
++    // Unreachable
++  }
++
+   EfiBootManagerFreeLoadOption (&PlatformDefaultBootOption);
+ 
+   DEBUG ((DEBUG_ERROR, "[Bds] Unable to boot!\n"));
+diff --git a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+index ef3abe5b7a..a8a1cf9089 100644
+--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
++++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+@@ -1707,15 +1707,6 @@ PlatformBootManagerAfterConsole (
+ 
+   EfiBootManagerRefreshAllBootOption ();
+ 
+-  //
+-  // Register UEFI Shell
+-  //
+-  PlatformRegisterFvBootOption (
+-    &gUefiShellFileGuid,
+-    L"EFI Internal Shell",
+-    LOAD_OPTION_ACTIVE
+-    );
+-
+   RemoveStaleFvFileOptions ();
+   SetBootOrderFromQemu ();
+ 

--- a/edk2-stable202211/0020-edk2-stable202211-Shell-Report-shelldrop-status-to-the-hypervisor.patch
+++ b/edk2-stable202211/0020-edk2-stable202211-Shell-Report-shelldrop-status-to-the-hypervisor.patch
@@ -1,0 +1,49 @@
+From 101110a81fe43ccb59ece5af122bc7c5296efc8b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Johanna=20Am=C3=A9lie=20Schander?= <mimoja@amazon.de>
+Date: Wed, 13 Apr 2022 13:20:15 +0200
+Subject: [PATCH] Shell: Report shelldrop status to the hypervisor
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When we drop into a shell (becuase of a configuration issue which might be
+caused by a potential regression) we do not have any insights into it.
+By introducing "X-Nitro-ShellDrop" we are not able to pass the reason for the
+shell drop to allow for a metric on it.
+
+Signed-off-by: Johanna Amélie Schander <mimoja@amazon.de>
+Upstream-status: Not applicable
+Reviewed-by: Alexander Graf (AWS) <graf@amazon.de>
+Reviewed-by: Hendrik Borghorst <hborghor@amazon.de>
+
+diff --git a/ShellPkg/Application/Shell/Shell.c b/ShellPkg/Application/Shell/Shell.c
+index df00adfdfa..8ee92db1fd 100644
+--- a/ShellPkg/Application/Shell/Shell.c
++++ b/ShellPkg/Application/Shell/Shell.c
+@@ -624,6 +624,13 @@ UefiMain (
+         Status = DoStartupScript (ShellInfoObject.ImageDevPath, ShellInfoObject.FileDevPath);
+       }
+ 
++      CHAR16 *shellstatus = L"Shell";
++      gRT->SetVariable((CHAR16*)L"X-Nitro-ShellDrop",                   \
++        &gShellVariableGuid,                                            \
++        EFI_VARIABLE_NON_VOLATILE|EFI_VARIABLE_BOOTSERVICE_ACCESS,      \
++        StrLen(shellstatus) * 2,                                     \
++        (VOID*) shellstatus);
++
+       if (!ShellInfoObject.ShellInitSettings.BitUnion.Bits.Exit && !ShellCommandGetExit () && ((PcdGet8 (PcdShellSupportLevel) >= 3) || PcdGetBool (PcdShellForceConsole)) && !EFI_ERROR (Status) && !ShellInfoObject.ShellInitSettings.BitUnion.Bits.NoConsoleIn) {
+         //
+         // begin the UI waiting loop
+@@ -1371,6 +1378,12 @@ DoStartupScript (
+ 
+   FileStringPath = LocateStartupScript (ImagePath, FilePath);
+   if (FileStringPath != NULL) {
++    // We don't introduce an enum in case a customer ever wants to see the data
++    gRT->SetVariable((CHAR16*)L"X-Nitro-ShellDrop",                   \
++      &gShellVariableGuid,                                            \
++      EFI_VARIABLE_NON_VOLATILE|EFI_VARIABLE_BOOTSERVICE_ACCESS,      \
++      StrLen(mStartupScript) * 2,                                     \
++      (VOID*) mStartupScript);
+     FullFileStringPath = FullyQualifyPath (FileStringPath);
+     if (FullFileStringPath == NULL) {
+       Status = RunScriptFile (FileStringPath, NULL, FileStringPath, ShellInfoObject.NewShellParametersProtocol);

--- a/edk2-stable202211/0021-edk2-stable202211-ExtVarStore-Ensure-spinlock-to-be-in-RuntimeMemory.patch
+++ b/edk2-stable202211/0021-edk2-stable202211-ExtVarStore-Ensure-spinlock-to-be-in-RuntimeMemory.patch
@@ -1,0 +1,187 @@
+From 9c224365f3dbd55bd543fe49a7666d74477348ac Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Johanna=20Am=C3=A9lie=20Schander?= <mimoja@amazon.de>
+Date: Wed, 11 May 2022 18:08:08 +0200
+Subject: [PATCH] ExtVarStore: Ensure spinlock to be in RuntimeMemory
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+So far we have stored the var_lock spinlock in the RT_CODE section.
+This now leads to issues with operating systems where the EFIs RT_CODE section
+is mapped read-only (as it should) resulting in access violations if
+the spinlock is aquired.
+
+These access violations are not recoverable by an generic (aka non-amazon aware)
+kernel leading to kernel crashes and failed boots.
+
+We therefore ensure the spinlock is stored in the RT_DATA section where it should
+have been from the beginning.
+
+CC: Hendrik Borghorst <hborghor@amazon.com>
+Signed-off-by: Johanna Amélie Schander <mimoja@amazon.de>
+Signed-off-by: Alex Graf  <graf@amazon.com>
+Reviewed-by: Alexander Graf (AWS) <graf@amazon.de>
+Reviewed-by: Hendrik Borghorst <hborghor@amazon.de>
+
+Upstream-status: Not applicable
+
+diff --git a/nitro/ExtVarStore/ExtVarStore.c b/nitro/ExtVarStore/ExtVarStore.c
+index 0b4aa0a07f..03a7d0896c 100644
+--- a/nitro/ExtVarStore/ExtVarStore.c
++++ b/nitro/ExtVarStore/ExtVarStore.c
+@@ -41,7 +41,7 @@ static EFI_EVENT mExtVirtualAddressChangeEvent = NULL;
+ static UINTN mExtVarMMIO = EXTVAR_MMIO_ADDRESS;
+ #endif
+ 
+-static SPIN_LOCK var_lock;
++static SPIN_LOCK *var_lock;
+ 
+ static VOID *comm_buf_phys;
+ VOID *comm_buf;
+@@ -95,7 +95,7 @@ ExtGetVariable (
+     return EFI_NOT_FOUND;
+   }
+ 
+-  AcquireSpinLock(&var_lock);
++  AcquireSpinLock(var_lock);
+ 
+   uefi_param_buf buf = {
+     .buf = comm_buf,
+@@ -150,7 +150,7 @@ ExtGetVariable (
+   }
+ 
+ out:
+-  ReleaseSpinLock(&var_lock);
++  ReleaseSpinLock(var_lock);
+ 
+   /* Deserialization failure */
+   if (rc != EFI_SUCCESS) {
+@@ -191,7 +191,7 @@ ExtGetNextVariableName (
+   if (StrSize(VariableName) > *VariableNameSize)
+       return EFI_INVALID_PARAMETER;
+ 
+-  AcquireSpinLock(&var_lock);
++  AcquireSpinLock(var_lock);
+ 
+   rc = serialize_uint32(&writer, VAR_STORE_VERSION);
+   rc |= serialize_command(&writer, COMMAND_GET_NEXT_VARIABLE);
+@@ -230,7 +230,7 @@ ExtGetNextVariableName (
+   }
+ 
+ out:
+-  ReleaseSpinLock(&var_lock);
++  ReleaseSpinLock(var_lock);
+ 
+   /* Deserialization failure */
+   if (rc != EFI_SUCCESS) {
+@@ -276,7 +276,7 @@ ExtSetVariable (
+     .buf = buf,
+   };
+ 
+-  AcquireSpinLock(&var_lock);
++  AcquireSpinLock(var_lock);
+ 
+   rc = serialize_uint32(&writer, VAR_STORE_VERSION);
+   rc |= serialize_command(&writer, COMMAND_SET_VARIABLE);
+@@ -287,7 +287,7 @@ ExtSetVariable (
+ 
+   /* Serialization failure */
+   if (rc != EFI_SUCCESS) {
+-    ReleaseSpinLock(&var_lock);
++    ReleaseSpinLock(var_lock);
+     return EFI_DEVICE_ERROR;
+   }
+ 
+@@ -295,7 +295,7 @@ ExtSetVariable (
+ 
+   rc = unserialize_result(&parser, &status);
+ 
+-  ReleaseSpinLock(&var_lock);
++  ReleaseSpinLock(var_lock);
+ 
+   /* Deserialization failure */
+   if (rc != EFI_SUCCESS) {
+@@ -332,7 +332,7 @@ ExtQueryVariableInfo (
+     .buf = buf,
+   };
+ 
+-  AcquireSpinLock(&var_lock);
++  AcquireSpinLock(var_lock);
+ 
+   rc = serialize_uint32(&writer, VAR_STORE_VERSION);
+   rc |= serialize_command(&writer, COMMAND_QUERY_VARIABLE_INFO);
+@@ -359,7 +359,7 @@ ExtQueryVariableInfo (
+   }
+ 
+ out:
+-  ReleaseSpinLock(&var_lock);
++  ReleaseSpinLock(var_lock);
+ 
+   /* Deserialization failure */
+   if (rc != EFI_SUCCESS) {
+@@ -387,21 +387,21 @@ OnExitBootServices (
+     .buf = buf,
+   };
+ 
+-  AcquireSpinLock(&var_lock);
++  AcquireSpinLock(var_lock);
+ 
+   rc = serialize_uint32(&writer, VAR_STORE_VERSION);
+   rc |= serialize_command(&writer, COMMAND_ENTER_RUNTIME);
+ 
+   /* Serialization failure */
+   if (rc != EFI_SUCCESS) {
+-    ReleaseSpinLock(&var_lock);
++    ReleaseSpinLock(var_lock);
+     return;
+   }
+ 
+   // We dont care about the return value, we cannot do anything with it anyways
+   exec_command(comm_buf_phys);
+ 
+-  ReleaseSpinLock(&var_lock);
++  ReleaseSpinLock(var_lock);
+ }
+ 
+ 
+@@ -413,7 +413,7 @@ VariableClassAddressChangeEvent (
+   IN VOID             *Context
+   )
+ {
+-  AcquireSpinLock(&var_lock);
++  AcquireSpinLock(var_lock);
+   /*
+    * Convert the comm_buf pointer from a physical to a virtual address for use
+    * at runtime.
+@@ -422,7 +422,10 @@ VariableClassAddressChangeEvent (
+ #ifdef EXTVAR_MMIO_ADDRESS
+   EfiConvertPointer (0x0, (VOID **) &mExtVarMMIO);
+ #endif
+-  ReleaseSpinLock(&var_lock);
++
++  ReleaseSpinLock(var_lock);
++
++  EfiConvertPointer (0x0, (VOID **) &var_lock);
+ }
+ 
+ STATIC
+@@ -478,6 +481,10 @@ ExtVarStoreInit(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
+     return EFI_OUT_OF_RESOURCES;
+   comm_buf = comm_buf_phys;
+ 
++  var_lock = AllocateRuntimeZeroPool(sizeof(*var_lock));
++  if (var_lock == NULL)
++    return EFI_OUT_OF_RESOURCES;
++
+   /* Check if a driver already registered, that should not happen */
+   VOID *DummyProtocol;
+   Status = gBS->LocateProtocol (
+@@ -489,7 +496,7 @@ ExtVarStoreInit(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
+   if (Status == EFI_SUCCESS) {
+     CpuDeadLoop();
+   }
+-  InitializeSpinLock(&var_lock);
++  InitializeSpinLock(var_lock);
+ 
+   // Taken from FSVariable.c
+   SystemTable->RuntimeServices->GetVariable         = ExtGetVariable;

--- a/edk2-stable202211/0022-edk2-stable202211-UEFI-NVMe-Increase-NVMe-generic-timeout-to-5-minutes.patch
+++ b/edk2-stable202211/0022-edk2-stable202211-UEFI-NVMe-Increase-NVMe-generic-timeout-to-5-minutes.patch
@@ -1,0 +1,30 @@
+From c909f38f074b191f310444041c940227b8dfc437 Mon Sep 17 00:00:00 2001
+From: Hendrik Borghorst <hborghor@amazon.de>
+Date: Thu, 29 Sep 2022 15:15:56 +0000
+Subject: [PATCH] UEFI/NVMe: Increase NVMe generic timeout to 5 minutes
+
+Sometimes EBS servers might time out if the timeout value is too low. To
+put our UEFI guest firmware in sync with legacy BIOS increase the limit to
+5 minutes.
+
+Upstream-status: Not applicable
+
+Signed-off-by: Hendrik Borghorst <hborghor@amazon.de>
+Reviewed-by: Anselm Busse <abusse@amazon.de>
+Reviewed-by: Petre Eftime <epetre@amazon.com>
+Reviewed-by: Ilias Stamatis <ilstam@amazon.co.uk>
+Reviewed-by: Simon Veith <sveith@amazon.de>
+
+diff --git a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
+index 4c26b2e1b4..059c6a171a 100644
+--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
++++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
+@@ -80,7 +80,7 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
+ //
+ // Time out value for Nvme transaction execution
+ //
+-#define NVME_GENERIC_TIMEOUT  EFI_TIMER_PERIOD_SECONDS (5)
++#define NVME_GENERIC_TIMEOUT  EFI_TIMER_PERIOD_SECONDS (5 * 60)
+ 
+ //
+ // Nvme async transfer timer interval, set by experience.

--- a/edk2-stable202211/0023-edk2-stable202211-ExtVarStore-Add-support-for-PIO-transfer.patch
+++ b/edk2-stable202211/0023-edk2-stable202211-ExtVarStore-Add-support-for-PIO-transfer.patch
@@ -1,0 +1,276 @@
+From a927427a30168ce0059bfb71795feb6c51b8aa06 Mon Sep 17 00:00:00 2001
+From: Alexander Graf <graf@amazon.com>
+Date: Tue, 7 Feb 2023 03:42:04 +0000
+Subject: [PATCH] ExtVarStore: Add support for PIO transfer
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In some environments, memory transfer during runtime with physical
+offsets does not work. If we detect such an environment, let's fall back
+to an emergency PIO based transfer mechanism.
+
+This PIO based transfer mechanism copies the local runtime buffer over
+to the the hypervisor, then initiates a command and receives the return
+buffer back into the runtime buffer region. We put in multiple safe
+guards to ensure we retry if the hypervisor buffer disappeared in
+between, for example because of a live-update operation.
+
+Upstream-status: Not applicable
+
+Signed-off-by: Alexander Graf <graf@amazon.com>
+Reviewed-by: Hendrik Borghorst <hborghor@amazon.de>
+Reviewed-by: Johanna 'Mimoja' Amélie Schander <mimoja@amazon.de>
+
+diff --git a/nitro/ExtVarStore/ExtVarStore.c b/nitro/ExtVarStore/ExtVarStore.c
+index 03a7d0896c..d1305254a8 100644
+--- a/nitro/ExtVarStore/ExtVarStore.c
++++ b/nitro/ExtVarStore/ExtVarStore.c
+@@ -46,15 +46,112 @@ static SPIN_LOCK *var_lock;
+ static VOID *comm_buf_phys;
+ VOID *comm_buf;
+ 
++#define BOUNCE_ATTEMPTS_MAX 2
++
++static BOOLEAN bounceData = FALSE;
++
++STATIC EFI_STATUS read_feature_flags(struct feature_word *features);
++
++STATIC VOID
++ExtVarStoreWrite32(UINT32 val)
++{
++#ifdef EXTVAR_MMIO_ADDRESS
++  MmioWrite32 (mExtVarMMIO, val);
++#else
++  IoWrite32 (EXTVAR_PORT_ADDRESS, val);
++#endif
++}
++
++STATIC UINT32
++ExtVarStoreRead32(VOID)
++{
++#ifdef EXTVAR_MMIO_ADDRESS
++  return MmioRead32 (mExtVarMMIO);
++#else
++  return IoRead32 (EXTVAR_PORT_ADDRESS);
++#endif
++}
++
++STATIC VOID exec_bounce(UINT8 *buf, UINTN len)
++{
++  UINT32 crc32, local_crc32;
++  UINT32 attempts;
++  UINT16 outsize;
++  UINT32 i, value;
++  struct transfer_in transfer = {
++    .magic_value = TRANSFER_KICK_MAGIC,
++  };
++  struct transfer_in kick = {
++    .magic_value = TRANSFER_KICK_MAGIC,
++  };
++
++  /*
++   * Try multiple times on failure. This can happen if the host erases
++   * the transfer buffer while we were transferring data.
++   */
++  for (attempts = 0; attempts < BOUNCE_ATTEMPTS_MAX; attempts++) {
++    /* Send buffer content to host */
++    for (i = 0; i < len; i += sizeof(transfer.u.data)) {
++      transfer.magic_value = TRANSFER_STREAM_MAGIC;
++      transfer.u.data[0] = buf[i];
++      transfer.u.data[1] = buf[i + 1];
++
++      ExtVarStoreWrite32 (*(UINT32 *)&transfer);
++    }
++
++    /* Kick off the operation */
++    kick.u.len = i,
++    ExtVarStoreWrite32 (*(UINT32 *)&kick);
++
++    /* Initialize the buffer so we can checksum */
++    SetMem(comm_buf, SHMEM_PAGES * EFI_PAGE_SIZE, 0xaa);
++
++    outsize = (UINT16) ExtVarStoreRead32 ();
++
++    if (!outsize || (outsize & 3)) {
++      /* Too little or unaligned data means something went wrong, reset */
++      kick.u.len = TRANSFER_INVALID_LEN;
++      ExtVarStoreWrite32 (*(UINT32 *)&kick);
++      continue;
++    }
++
++    crc32 = ExtVarStoreRead32 ();
++    outsize -= sizeof(crc32);
++
++    /* Copy return buffer back to guest */
++    for (i = outsize; i > 0; i -= sizeof(value)) {
++      value = ExtVarStoreRead32 ();
++
++      CopyMem (&buf[i - sizeof(value)], &value, sizeof(value));
++    }
++
++    /* Validate checksum */
++    local_crc32 = CalculateCrc32 (buf, outsize);
++    if (crc32 == local_crc32)
++      break;
++
++    /* Let's dump the buffer */
++    DEBUG ((DEBUG_ERROR, "Invalid checksum: 0x%08x | 0x%08x\n", crc32, local_crc32));
++
++    for (i = 0; i < outsize; i++) {
++      DEBUG ((DEBUG_ERROR, "buf[%d] = 0x%02x\n", i, buf[i]));
++    }
++  }
++}
++
+ static void
+-exec_command(VOID *buf)
++exec_command(VOID *buf, UINTN len)
+ {
+   MemoryFence ();
++  if (bounceData) {
++    exec_bounce (comm_buf, len);
++  } else {
+ #ifdef EXTVAR_MMIO_ADDRESS
+-  MmioWrite64 (mExtVarMMIO, ((UINTN)buf) >> 12);
++    MmioWrite64 (mExtVarMMIO, ((UINTN)buf) >> EFI_PAGE_SHIFT);
+ #else
+-  IoWrite32 (EXTVAR_PORT_ADDRESS, ((UINTN)buf) >> 12);
++    IoWrite32 (EXTVAR_PORT_ADDRESS, ((UINTN)buf) >> EFI_PAGE_SHIFT);
+ #endif
++  }
+   MemoryFence ();
+ }
+ 
+@@ -62,11 +159,7 @@ static UINT32 read_interface()
+ {
+   UINT32 value;
+   MemoryFence ();
+-#ifdef EXTVAR_MMIO_ADDRESS
+-  value = MmioRead32 (mExtVarMMIO);
+-#else
+-  value = IoRead32 (EXTVAR_PORT_ADDRESS);
+-#endif
++  value = ExtVarStoreRead32 ();
+   MemoryFence ();
+   return value;
+ }
+@@ -120,7 +213,7 @@ ExtGetVariable (
+   if (rc != EFI_SUCCESS)
+     goto out;
+ 
+-  exec_command(comm_buf_phys);
++  exec_command(comm_buf_phys, buf.remaining - writer.buf.remaining);
+ 
+   rc = unserialize_result(&parser, &status);
+   if (rc != EFI_SUCCESS)
+@@ -203,7 +296,7 @@ ExtGetNextVariableName (
+   if (rc != EFI_SUCCESS)
+     goto out;
+ 
+-  exec_command(comm_buf_phys);
++  exec_command(comm_buf_phys, buf.remaining - writer.buf.remaining);
+ 
+   rc = unserialize_result(&parser, &status);
+   if (rc != EFI_SUCCESS)
+@@ -291,7 +384,7 @@ ExtSetVariable (
+     return EFI_DEVICE_ERROR;
+   }
+ 
+-  exec_command(comm_buf_phys);
++  exec_command(comm_buf_phys, buf.remaining - writer.buf.remaining);
+ 
+   rc = unserialize_result(&parser, &status);
+ 
+@@ -342,7 +435,7 @@ ExtQueryVariableInfo (
+   if (rc != EFI_SUCCESS)
+     goto out;
+ 
+-  exec_command(comm_buf_phys);
++  exec_command(comm_buf_phys, buf.remaining - writer.buf.remaining);
+ 
+   rc = unserialize_result(&parser, &status);
+   if (rc != EFI_SUCCESS)
+@@ -399,7 +492,7 @@ OnExitBootServices (
+   }
+ 
+   // We dont care about the return value, we cannot do anything with it anyways
+-  exec_command(comm_buf_phys);
++  exec_command(comm_buf_phys, buf.remaining - writer.buf.remaining);
+ 
+   ReleaseSpinLock(var_lock);
+ }
+diff --git a/nitro/ExtVarStore/interface.h b/nitro/ExtVarStore/interface.h
+index 87d3d8ae31..8b5967528b 100644
+--- a/nitro/ExtVarStore/interface.h
++++ b/nitro/ExtVarStore/interface.h
+@@ -31,10 +31,68 @@ enum command_t {
+  */
+ #define VAR_STORE_MAGIC_VALUE 0xec
+ 
++#pragma pack (1)
+ struct feature_word {
+   UINT8 magic_value;
+   UINT32 features:24;
+-} _packed;
++};
++#pragma pack ()
++
++/* Magic value to indicate that a TRANSFER write is a transfer buffer transfer */
++#define TRANSFER_STREAM_MAGIC 0xffec
++
++#pragma pack (1)
++struct transfer_in {
++        UINT16 magic_value;
++        union {
++                UINT8 data[2];
++                UINT16 len;
++        } u;
++};
++#pragma pack ()
++
++/* Magic value to indicate that a TRANSFER write is a transfer buffer kick */
++#define TRANSFER_KICK_MAGIC 0xffed
++
++/* Length value to indicate invalid data */
++#define TRANSFER_INVALID_LEN 0xffff
++
++/*
++ * When the CRC32 feature is available, every command response automatically
++ * generates a CRC32 checksum trailing its contents. That way, the receiving
++ * end can validate whether all data is correct after full deserialization.
++ * Alternatively, they can use this feature in combination with TRANSFER
++ * which allows them to validate whether the bounce buffer was copied correctly.
++ */
++#define FEATURE_CRC32       0x1
++
++/*
++ * When the TRANSFER feature is available, the I/O register receives a state
++ * machine with additional semantics that allow a guest to transfer data
++ * into a buffer in vmm as well as receive the response from the buffer.
++ *
++ * To use the TRANSFER feature, the guest needs to transmit its request into a
++ * temporary buffer in vmm using `struct transfer_in` writes with
++ * `idx == TRANSFER_STREAM_MAGIC` and 2 bytes of data in each I/O write to the
++ * register. Once transferred, it issues a `struct transfer_in` write with
++ * `idx == TRANSFER_KICK_MAGIC` and the length of the just written data in its
++ * `len` field.
++ *
++ * Once the write returns, the guest can read the response buffer using the
++ * same I/O port in 32bit read mode. The first 32bit word contains the length
++ * of the full response payload including CRC32. The next 32bit word contains
++ * the CRC32 checksum of the full response payload.
++ *
++ * After that, each 32bit read returns a little endian 32bit part of the
++ * response buffer, in descending order. The first response will contain the
++ * last 4 bytes, the next one the 4 bytes before that and so on. Guests should
++ * read the I/O port for response data for as many words as necessary to
++ * transfer the full buffer as described through the previously returned size.
++ *
++ * On error, guests can issue a `TRANSFER_KICK_MAGIC` write command with
++ * invalid `len` field. This will cause a reset of the internal state machine.
++ */
++#define FEATURE_TRANSFER    0x2
+ 
+ typedef struct {
+ 	CHAR8 *buf;

--- a/edk2-stable202211/0024-edk2-stable202211-ExtVarStore-Use-TRANSFER-when-we-run-in-SEV.patch
+++ b/edk2-stable202211/0024-edk2-stable202211-ExtVarStore-Use-TRANSFER-when-we-run-in-SEV.patch
@@ -1,0 +1,99 @@
+From 691639a27469688573a800aa75da7f17b2fbd3dd Mon Sep 17 00:00:00 2001
+From: Alexander Graf <graf@amazon.com>
+Date: Tue, 7 Feb 2023 12:53:07 +0000
+Subject: [PATCH] ExtVarStore: Use TRANSFER when we run in SEV
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When we run in SEV-SNP, we can not rely on a shared memory buffer for
+host and guest communication. In that case, let's fall back to the newly
+introduced TRANSFER mode that allows us to serialize the UEFI requests
+through a non-RAM protocol.
+
+Upstream-status: Not applicable
+
+Signed-off-by: Alexander Graf <graf@amazon.com>
+Reviewed-by: Hendrik Borghorst <hborghor@amazon.de>
+Reviewed-by: Johanna 'Mimoja' Amélie Schander <mimoja@amazon.de>
+
+diff --git a/nitro/ExtVarStore/ExtVarStore.c b/nitro/ExtVarStore/ExtVarStore.c
+index d1305254a8..bcac0eb979 100644
+--- a/nitro/ExtVarStore/ExtVarStore.c
++++ b/nitro/ExtVarStore/ExtVarStore.c
+@@ -12,6 +12,10 @@
+ #include <Library/UefiLib.h>
+ #include <Library/SynchronizationLib.h>
+ 
++#ifdef MDE_CPU_X64
++#include <Library/MemEncryptSevLib.h>
++#endif
++
+ #include <Library/DxeServicesTableLib.h>
+ #include <Library/UefiBootServicesTableLib.h>
+ 
+@@ -523,11 +527,10 @@ VariableClassAddressChangeEvent (
+ 
+ STATIC
+ EFI_STATUS
+-read_feature_flags()
++read_feature_flags(struct feature_word *features)
+ {
+   /* Check for magic value before parsing the flags */
+-  UINT32 value = read_interface ();
+-  struct feature_word *features = (struct feature_word *)&value;
++  *(UINT32 *)features = read_interface ();
+ 
+   if (features->magic_value != VAR_STORE_MAGIC_VALUE)
+     return EFI_UNSUPPORTED;
+@@ -551,6 +554,7 @@ ExtVarStoreInit(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
+ {
+   EFI_STATUS Status = EFI_SUCCESS;
+   EFI_EVENT ExitBootServiceEvent;
++  struct feature_word features = {};
+ 
+ #ifdef EXTVAR_MMIO_ADDRESS
+   Status = gDS->AddMemorySpace (
+@@ -566,7 +570,7 @@ ExtVarStoreInit(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
+   ASSERT_EFI_ERROR (Status);
+ #endif
+ 
+-  if (read_feature_flags() != EFI_SUCCESS)
++  if (read_feature_flags(&features) != EFI_SUCCESS)
+     return EFI_UNSUPPORTED;
+ 
+   comm_buf_phys = AllocateRuntimePages(SHMEM_PAGES);
+@@ -574,6 +578,13 @@ ExtVarStoreInit(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
+     return EFI_OUT_OF_RESOURCES;
+   comm_buf = comm_buf_phys;
+ 
++#ifdef MDE_CPU_X64
++  if (MemEncryptSevIsEnabled () &&
++      (features.features & FEATURE_CRC32) &&
++      (features.features & FEATURE_TRANSFER))
++    bounceData = TRUE;
++#endif
++
+   var_lock = AllocateRuntimeZeroPool(sizeof(*var_lock));
+   if (var_lock == NULL)
+     return EFI_OUT_OF_RESOURCES;
+diff --git a/nitro/ExtVarStore/ExtVarStore.inf b/nitro/ExtVarStore/ExtVarStore.inf
+index 09c75ee5dd..c614591ed9 100644
+--- a/nitro/ExtVarStore/ExtVarStore.inf
++++ b/nitro/ExtVarStore/ExtVarStore.inf
+@@ -22,6 +22,7 @@
+ [Packages]
+   MdePkg/MdePkg.dec
+   MdeModulePkg/MdeModulePkg.dec
++  OvmfPkg/OvmfPkg.dec
+ 
+ [LibraryClasses]
+   PcdLib
+@@ -41,6 +42,7 @@
+ 
+ [LibraryClasses.X64]
+   PciLib
++  MemEncryptSevLib
+ 
+ [Guids]
+   gEfiEventExitBootServicesGuid                 ## CONSUMES ## Event

--- a/edk2-stable202211/0025-edk2-stable202211-ExtVarStore-Add-hook-to-force-enable-TRANSFER.patch
+++ b/edk2-stable202211/0025-edk2-stable202211-ExtVarStore-Add-hook-to-force-enable-TRANSFER.patch
@@ -1,0 +1,42 @@
+From fb18a9de632e94ed7f62ff225741b82a78bac738 Mon Sep 17 00:00:00 2001
+From: Alexander Graf <graf@amazon.com>
+Date: Tue, 7 Feb 2023 14:45:45 +0000
+Subject: [PATCH] ExtVarStore: Add hook to force enable TRANSFER
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We want to give other modules the ability to switch to TRANSFER mode if
+they detect that we are not running in an environment that is compatible
+with the shared physical page concept. Let's add a special variable
+called "X-Nitro-Force-TRANSFER" that when set toggles the system wide
+mode to TRANSFER based.
+
+Upstream-status: Not applicable
+
+Signed-off-by: Alexander Graf <graf@amazon.com>
+Reviewed-by: Hendrik Borghorst <hborghor@amazon.de>
+Reviewed-by: Johanna 'Mimoja' Amélie Schander <mimoja@amazon.de>
+
+diff --git a/nitro/ExtVarStore/ExtVarStore.c b/nitro/ExtVarStore/ExtVarStore.c
+index bcac0eb979..f8924fd765 100644
+--- a/nitro/ExtVarStore/ExtVarStore.c
++++ b/nitro/ExtVarStore/ExtVarStore.c
+@@ -360,6 +360,17 @@ ExtSetVariable (
+   if (VariableName[0] == '\0')
+     return EFI_INVALID_PARAMETER;
+ 
++  /* Magic key to enable TRANSFER based transport */
++  if (StrCmp(VariableName, L"X-Nitro-Force-TRANSFER") == 0) {
++    struct feature_word features = {};
++
++    if ((read_feature_flags(&features) == EFI_SUCCESS) &&
++        (features.features & FEATURE_CRC32) &&
++        (features.features & FEATURE_TRANSFER)) {
++      bounceData = TRUE;
++    }
++  }
++
+   uefi_param_buf buf = {
+     .buf = comm_buf,
+     .remaining = SHMEM_PAGES * EFI_PAGE_SIZE,


### PR DESCRIPTION
We introduce the patches needed to build UEFI images for Nitro. These are based on the edk2-stable202211 release of edk2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
