### PR TITLE
Fix patch 0001 to enable TPM2 support

### DIFF
--- a/edk2-stable202211/0001-edk2-stable202211-nitro-add-build-script.patch
+++ b/edk2-stable202211/0001-edk2-stable202211-nitro-add-build-script.patch
@@ -95,7 +95,7 @@ index 0000000000..b7fc92bae7
 +	    # Build OVMF for booting x86_64 Nitro Guests
 +	    echo "     BUILD  OvmfPkg"
 +
-+	    defines="${defines} -DTPM_ENABLE=TRUE"
++	    defines="${defines} -DTPM2_ENABLE=TRUE"
 +	    [ -n "$UEFI_DEBUG" ] && defines="${defines} -DDEBUG_ON_SERIAL_PORT"
 +
 +	    build -a X64 -t $TOOLCHAIN -b $BUILD_TYPE --hash -p OvmfPkg/OvmfPkgX64.dsc ${defines} >> "${LOGFILE}"


### PR DESCRIPTION
Starting with commit 4de8d61bce ("OvmfPkg: rework TPM configuration"), TPM support moved from under TPM_ENABLE to TPM2_ENABLE and TPM1_ENABLE.

Adjust patch 0001 to correctly enable TPM support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
