### PR TITLE
OvmfPkg: disable TPM2 SHA1

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -53,6 +53,7 @@ pkgs.stdenv.mkDerivation rec {
     ./edk2-stable202211/0025-edk2-stable202211-ExtVarStore-Add-hook-to-force-enable-TRANSFER.patch
     ./edk2-stable202211/0026-edk2-stable202211-OvmfPkg-PlatformPei-Initialize-SEV-immediately-after-RAM.patch
     ./edk2-stable202211/0027-edk2-stable202211-Skip-reserved-memory-in-high-memory-from-SEV-SNP-prevalidation.patch
+    ./edk2-stable202211/0028-edk2-stable202211-OvmfPkg-disable-TPM2-SHA1.patch
     ./edk2-stable202211/9001-Remove-Wno-format-compiling-flag-for-Openssl-files.patch
   ];
 

--- a/edk2-stable202211/0028-edk2-stable202211-OvmfPkg-disable-TPM2-SHA1.patch
+++ b/edk2-stable202211/0028-edk2-stable202211-OvmfPkg-disable-TPM2-SHA1.patch
@@ -1,0 +1,28 @@
+From 5add67a0a4e666602fdec98138fc2127be380391 Mon Sep 17 00:00:00 2001
+From: Petre Eftime <epetre@amazon.com>
+Date: Mon, 15 May 2023 15:24:53 +0000
+Subject: [PATCH] OvmfPkg: disable TPM2 SHA1
+
+SHA1 is no longer a strong enough algorithm for many(most) usecases. This
+commit disables SHA1 as a default so that it's not used by mistake
+in attestation policies. If required, it can be reactivated via the PPI
+for any particular usecase that still depends on SHA1.
+
+Signed-off-by: Petre Eftime <epetre@amazon.com>
+---
+ OvmfPkg/OvmfTpmPcds.dsc.inc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/OvmfPkg/OvmfTpmPcds.dsc.inc b/OvmfPkg/OvmfTpmPcds.dsc.inc
+index 0d55d62737..e9271b0273 100644
+--- a/OvmfPkg/OvmfTpmPcds.dsc.inc
++++ b/OvmfPkg/OvmfTpmPcds.dsc.inc
+@@ -4,4 +4,5 @@
+ 
+ !if $(TPM2_ENABLE) == TRUE
+   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid|{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
++  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask|0x1E
+ !endif
+-- 
+2.39.2
+


### PR DESCRIPTION
*Description of changes:*
SHA1 is no longer a strong enough algorithm for many(most) usecases. This
commit disables SHA1 as a default so that it's not used by mistake
in attestation policies. If required, it can be reactivated via the PPI
for any particular usecase that still depends on SHA1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
