### PR TITLE
disable TPM12

### DIFF
--- a/edk2-stable202211/0001-edk2-stable202211-nitro-add-build-script.patch
+++ b/edk2-stable202211/0001-edk2-stable202211-nitro-add-build-script.patch
@@ -95,7 +95,7 @@ index 0000000000..b7fc92bae7
 +	    # Build OVMF for booting x86_64 Nitro Guests
 +	    echo "     BUILD  OvmfPkg"
 +
-+	    defines="${defines} -DTPM2_ENABLE=TRUE"
++	    defines="${defines} -DTPM2_ENABLE=TRUE -DTPM1_ENABLE=FALSE"
 +	    [ -n "$UEFI_DEBUG" ] && defines="${defines} -DDEBUG_ON_SERIAL_PORT"
 +
 +	    build -a X64 -t $TOOLCHAIN -b $BUILD_TYPE --hash -p OvmfPkg/OvmfPkgX64.dsc ${defines} >> "${LOGFILE}"


### PR DESCRIPTION
*Description of changes:*
TPM12 support is not needed for Nitro, so it can be safely removed.

Adjust patch 0001 to accomodate this change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
