### PR TITLE
default.nix: don't use unquoted urls

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -93,7 +93,7 @@ pkgs.stdenv.mkDerivation rec {
 
   meta = {
     description = "UEFI edk2 for Nitro";
-    homepage = https://github.com/aws/uefi;
+    homepage = "https://github.com/aws/uefi";
     license = "bsd";
   };
 }


### PR DESCRIPTION
*Issue #, if available:* - 

*Description of changes:*

Quoting from https://nix.dev/guides/best-practices.html#urls

The Nix language syntax supports bare URLs, so one could write https://example.com instead of "https://example.com"

[RFC 45](https://github.com/NixOS/rfcs/pull/45) was accepted to deprecate unquoted URLs and provides a number of arguments how this feature does more harm than good.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
